### PR TITLE
Relaxed `Sized` constraints for encoders

### DIFF
--- a/crates/pindakaas/src/bool_linear.rs
+++ b/crates/pindakaas/src/bool_linear.rs
@@ -21,8 +21,8 @@ use crate::{
 	},
 	propositional_logic::{Formula, TseitinEncoder},
 	sorted::{Sorted, SortedEncoder},
-	BoolVal, Checker, ClauseDatabase, ClauseDatabaseTools, Coeff, Encoder, IntEncoding, Lit,
-	Result, Unsatisfiable, Valuation,
+	AsDynClauseDatabase, BoolVal, Checker, ClauseDatabase, ClauseDatabaseTools, Coeff, Encoder,
+	IntEncoding, Lit, Result, Unsatisfiable, Valuation,
 };
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -220,7 +220,11 @@ impl AdderEncoder {
 	/// literals (full adder).
 	///
 	/// `output` can be either a literal, or a constant Boolean value.
-	fn carry_circuit<DB: ClauseDatabase>(db: &mut DB, input: &[Lit], output: BoolVal) -> Result {
+	fn carry_circuit<DB: ClauseDatabase + ?Sized>(
+		db: &mut DB,
+		input: &[Lit],
+		output: BoolVal,
+	) -> Result {
 		match output {
 			BoolVal::Lit(carry) => match *input {
 				[a, b] => {
@@ -267,7 +271,11 @@ impl AdderEncoder {
 	/// literals (full adder).
 	///
 	/// `output` can be either a literal, or a constant Boolean value.
-	fn sum_circuit<DB: ClauseDatabase>(db: &mut DB, input: &[Lit], output: BoolVal) -> Result {
+	fn sum_circuit<DB: ClauseDatabase + AsDynClauseDatabase>(
+		db: &mut DB,
+		input: &[Lit],
+		output: BoolVal,
+	) -> Result {
 		match output {
 			BoolVal::Lit(sum) => match *input {
 				[a, b] => {
@@ -332,7 +340,7 @@ impl AdderEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase> Encoder<DB, NormalizedBoolLinear> for AdderEncoder {
+impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, NormalizedBoolLinear> for AdderEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "adder_encoder", skip_all, fields(constraint = lin.trace_print()))
@@ -580,7 +588,7 @@ impl BddEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase> Encoder<DB, NormalizedBoolLinear> for BddEncoder {
+impl<DB: ClauseDatabase + ?Sized> Encoder<DB, NormalizedBoolLinear> for BddEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "bdd_encoder", skip_all, fields(constraint = lin.trace_print()))
@@ -656,7 +664,7 @@ impl BoolLinAggregator {
 		any(feature = "tracing", test),
 		tracing::instrument(name = "aggregator", skip_all, fields(constraint = lin.trace_print()))
 	)]
-	pub fn aggregate<DB: ClauseDatabase>(
+	pub fn aggregate<DB: ClauseDatabase + ?Sized>(
 		&self,
 		db: &mut DB,
 		lin: &BoolLinear,
@@ -1522,7 +1530,7 @@ impl From<LimitComp> for Comparator {
 }
 
 // Automatically implement Cardinality encoding when you can encode Linear constraints
-impl<DB: ClauseDatabase, Enc: Encoder<DB, NormalizedBoolLinear> + LinMarker>
+impl<DB: ClauseDatabase + ?Sized, Enc: Encoder<DB, NormalizedBoolLinear> + LinMarker>
 	Encoder<DB, Cardinality> for Enc
 {
 	fn encode(&self, db: &mut DB, con: &Cardinality) -> Result {
@@ -1553,7 +1561,7 @@ impl<Enc, Agg> LinearEncoder<Enc, Agg> {
 	}
 }
 
-impl<DB: ClauseDatabase, Enc: Encoder<DB, BoolLinVariant>> Encoder<DB, BoolLinear>
+impl<DB: ClauseDatabase + ?Sized, Enc: Encoder<DB, BoolLinVariant>> Encoder<DB, BoolLinear>
 	for LinearEncoder<Enc>
 {
 	#[cfg_attr(
@@ -1715,7 +1723,7 @@ impl<LinEnc, CardEnc, AmoEnc> StaticLinEncoder<LinEnc, CardEnc, AmoEnc> {
 }
 
 impl<
-		DB: ClauseDatabase,
+		DB: ClauseDatabase + ?Sized,
 		LinEnc: Encoder<DB, NormalizedBoolLinear>,
 		CardEnc: Encoder<DB, Cardinality>,
 		AmoEnc: Encoder<DB, CardinalityOne>,
@@ -1746,7 +1754,7 @@ impl SwcEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase> Encoder<DB, NormalizedBoolLinear> for SwcEncoder {
+impl<DB: ClauseDatabase + ?Sized> Encoder<DB, NormalizedBoolLinear> for SwcEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "swc_encoder", skip_all, fields(constraint = lin.trace_print()))
@@ -1864,7 +1872,7 @@ impl TotalizerEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase> Encoder<DB, NormalizedBoolLinear> for TotalizerEncoder {
+impl<DB: ClauseDatabase + ?Sized> Encoder<DB, NormalizedBoolLinear> for TotalizerEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "totalizer_encoder", skip_all, fields(constraint = lin.trace_print()))

--- a/crates/pindakaas/src/cardinality.rs
+++ b/crates/pindakaas/src/cardinality.rs
@@ -54,8 +54,8 @@ impl From<CardinalityOne> for Cardinality {
 }
 
 // Automatically implement AtMostOne encoding when you can encode Cardinality constraints
-impl<DB: ClauseDatabase, Enc: Encoder<DB, Cardinality> + CardMarker> Encoder<DB, CardinalityOne>
-	for Enc
+impl<DB: ClauseDatabase + ?Sized, Enc: Encoder<DB, Cardinality> + CardMarker>
+	Encoder<DB, CardinalityOne> for Enc
 {
 	fn encode(&self, db: &mut DB, con: &CardinalityOne) -> Result {
 		self.encode(db, &Cardinality::from(con.clone()))
@@ -83,7 +83,7 @@ impl Default for SortingNetworkEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase> Encoder<DB, Cardinality> for SortingNetworkEncoder {
+impl<DB: ClauseDatabase + ?Sized> Encoder<DB, Cardinality> for SortingNetworkEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "sorting_network_encoder", skip_all, fields(constraint = card.trace_print()))

--- a/crates/pindakaas/src/cardinality_one.rs
+++ b/crates/pindakaas/src/cardinality_one.rs
@@ -26,7 +26,7 @@ pub struct LadderEncoder {}
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct PairwiseEncoder {}
 
-pub(crate) fn at_least_one_clause<DB: ClauseDatabase>(
+pub(crate) fn at_least_one_clause<DB: ClauseDatabase + ?Sized>(
 	db: &mut DB,
 	card1: &CardinalityOne,
 ) -> Result {
@@ -34,7 +34,7 @@ pub(crate) fn at_least_one_clause<DB: ClauseDatabase>(
 	db.add_clause(card1.lits.iter().copied())
 }
 
-impl<DB: ClauseDatabase> Encoder<DB, CardinalityOne> for BitwiseEncoder {
+impl<DB: ClauseDatabase + ?Sized> Encoder<DB, CardinalityOne> for BitwiseEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "bitwise_encoder", skip_all, fields(constraint = card1.trace_print()))
@@ -87,7 +87,7 @@ impl Checker for CardinalityOne {
 	}
 }
 
-impl<DB: ClauseDatabase> Encoder<DB, CardinalityOne> for LadderEncoder {
+impl<DB: ClauseDatabase + ?Sized> Encoder<DB, CardinalityOne> for LadderEncoder {
 	#[cfg_attr(
 	any(feature = "tracing", test),
 	tracing::instrument(name = "ladder_encoder", skip_all, fields(constraint = card1.trace_print()))
@@ -115,7 +115,7 @@ impl<DB: ClauseDatabase> Encoder<DB, CardinalityOne> for LadderEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase> Encoder<DB, CardinalityOne> for PairwiseEncoder {
+impl<DB: ClauseDatabase + ?Sized> Encoder<DB, CardinalityOne> for PairwiseEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "pairwise_encoder", skip_all, fields(constraint = card1.trace_print()))

--- a/crates/pindakaas/src/helpers.rs
+++ b/crates/pindakaas/src/helpers.rs
@@ -1,3 +1,36 @@
+macro_rules! as_dyn_trait {
+	($as_dyn_name:ident, $trait_name:ident) => {
+		/// Helper trait that allows the creation of a dynamic reference to a trait
+		/// object. This trait is automatically implemented for all sized types that
+		/// implement the trait, and for the trait object itself.
+		pub trait $as_dyn_name {
+			/// Cast the object reference to a dynamic trait object reference.
+			fn as_dyn(&self) -> &dyn $trait_name;
+			/// Cast the object mutable reference to a mutable dynamic trait object
+			/// reference.
+			fn as_mut_dyn(&mut self) -> &mut dyn $trait_name;
+		}
+		impl<T: $trait_name> $as_dyn_name for T {
+			fn as_dyn(&self) -> &dyn $trait_name {
+				self
+			}
+			fn as_mut_dyn(&mut self) -> &mut dyn $trait_name {
+				self
+			}
+		}
+		impl $as_dyn_name for dyn $trait_name {
+			fn as_dyn(&self) -> &dyn $trait_name {
+				self
+			}
+			fn as_mut_dyn(&mut self) -> &mut dyn $trait_name {
+				self
+			}
+		}
+	};
+}
+
+as_dyn_trait!(AsDynClauseDatabase, ClauseDatabase);
+
 #[cfg(feature = "splr")]
 macro_rules! concat_slices {
     ([$init:expr; $T:ty]: $($s:expr),+ $(,)?) => {{
@@ -87,7 +120,7 @@ const FILTER_TRIVIAL_CLAUSES: bool = false;
 /// Adds clauses for a DNF formula (disjunction of conjunctions)
 /// Ex. (a /\ -b) \/ c == a \/ c /\ -b \/ c
 /// If any disjunction is empty, this satisfies the whole formula. If any element contains the empty conjunction, that element is falsified in the final clause.
-pub(crate) fn add_clauses_for<DB: ClauseDatabase>(
+pub(crate) fn add_clauses_for<DB: ClauseDatabase + ?Sized>(
 	db: &mut DB,
 	expression: Vec<Vec<Vec<Lit>>>,
 ) -> Result {

--- a/crates/pindakaas/src/integer.rs
+++ b/crates/pindakaas/src/integer.rs
@@ -117,7 +117,7 @@ pub(crate) fn display_dom(dom: &BTreeSet<Coeff>) -> String {
 	any(feature = "tracing", test),
 	tracing::instrument(name = "lex_geq", skip_all)
 )]
-pub(crate) fn lex_geq_const<DB: ClauseDatabase>(
+pub(crate) fn lex_geq_const<DB: ClauseDatabase + ?Sized>(
 	db: &mut DB,
 	x: &[Option<Lit>],
 	k: PosCoeff,
@@ -137,7 +137,7 @@ pub(crate) fn lex_geq_const<DB: ClauseDatabase>(
 	any(feature = "tracing", test),
 	tracing::instrument(name = "lex_lesseq_const", skip_all)
 )]
-pub(crate) fn lex_leq_const<DB: ClauseDatabase>(
+pub(crate) fn lex_leq_const<DB: ClauseDatabase + ?Sized>(
 	db: &mut DB,
 	x: &[Option<Lit>],
 	k: PosCoeff,
@@ -162,7 +162,7 @@ pub(crate) fn lex_leq_const<DB: ClauseDatabase>(
 /// Constrains the slice `z`, to be the result of adding `x` to `y`, all encoded using the log encoding.
 ///
 /// TODO: Should this use the IntEncoding::Log input??
-pub(crate) fn log_enc_add<DB: ClauseDatabase>(
+pub(crate) fn log_enc_add<DB: ClauseDatabase + ?Sized>(
 	db: &mut DB,
 	x: &[Lit],
 	y: &[Lit],
@@ -179,7 +179,7 @@ pub(crate) fn log_enc_add<DB: ClauseDatabase>(
 }
 
 #[cfg_attr(any(feature = "tracing", test), tracing::instrument(name = "log_enc_add", skip_all, fields(constraint = format!("{x:?} + {y:?} {cmp} {z:?}"))))]
-pub(crate) fn log_enc_add_<DB: ClauseDatabase>(
+pub(crate) fn log_enc_add_<DB: ClauseDatabase + ?Sized>(
 	db: &mut DB,
 	x: &[BoolVal],
 	y: &[BoolVal],
@@ -285,7 +285,7 @@ impl Checker for ImplicationChainConstraint {
 }
 
 impl ImplicationChainEncoder {
-	pub(crate) fn _encode<DB: ClauseDatabase>(
+	pub(crate) fn _encode<DB: ClauseDatabase + ?Sized>(
 		&mut self,
 		db: &mut DB,
 		ic: &ImplicationChainConstraint,
@@ -298,7 +298,7 @@ impl ImplicationChainEncoder {
 }
 
 impl IntVar {
-	fn encode<DB: ClauseDatabase>(
+	fn encode<DB: ClauseDatabase + ?Sized>(
 		&self,
 		db: &mut DB,
 		views: &mut FxHashMap<(usize, Coeff), Lit>,
@@ -401,7 +401,7 @@ impl Display for IntVar {
 }
 
 impl IntVarBin {
-	pub(crate) fn add<DB: ClauseDatabase>(
+	pub(crate) fn add<DB: ClauseDatabase + ?Sized>(
 		&self,
 		db: &mut DB,
 		encoder: &TernLeEncoder,
@@ -437,7 +437,7 @@ impl IntVarBin {
 		}
 	}
 
-	pub(crate) fn consistent<DB: ClauseDatabase>(&self, db: &mut DB) -> Result {
+	pub(crate) fn consistent<DB: ClauseDatabase + ?Sized>(&self, db: &mut DB) -> Result {
 		let encoder = TernLeEncoder::default();
 		if !GROUND_BINARY_AT_LB {
 			encoder.encode(
@@ -469,7 +469,7 @@ impl IntVarBin {
 		(self.lb..=self.ub).map(|i| i..(i + 1)).collect()
 	}
 	// TODO change to with_label or something
-	pub(crate) fn from_bounds<DB: ClauseDatabase>(
+	pub(crate) fn from_bounds<DB: ClauseDatabase + ?Sized>(
 		db: &mut DB,
 		lb: Coeff,
 		ub: Coeff,
@@ -569,7 +569,7 @@ impl Display for IntVarBin {
 }
 
 impl IntVarEnc {
-	pub(crate) fn add<DB: ClauseDatabase>(
+	pub(crate) fn add<DB: ClauseDatabase + ?Sized>(
 		&self,
 		db: &mut DB,
 		encoder: &TernLeEncoder,
@@ -641,7 +641,7 @@ impl IntVarEnc {
 		}
 	}
 
-	pub(crate) fn consistent<DB: ClauseDatabase>(&self, db: &mut DB) -> Result {
+	pub(crate) fn consistent<DB: ClauseDatabase + ?Sized>(&self, db: &mut DB) -> Result {
 		match self {
 			IntVarEnc::Ord(o) => o.consistent(db),
 			IntVarEnc::Bin(b) => b.consistent(db),
@@ -666,7 +666,7 @@ impl IntVarEnc {
 		}
 	}
 	/// Constructs (one or more) IntVar `ys` for linear expression `xs` so that ∑ xs ≦ ∑ ys
-	pub(crate) fn from_part<DB: ClauseDatabase>(
+	pub(crate) fn from_part<DB: ClauseDatabase + ?Sized>(
 		db: &mut DB,
 		xs: &Part,
 		ub: PosCoeff,
@@ -885,7 +885,7 @@ impl IntVarOrd {
 		}
 	}
 
-	pub(crate) fn consistent<DB: ClauseDatabase>(&self, db: &mut DB) -> Result {
+	pub(crate) fn consistent<DB: ClauseDatabase + ?Sized>(&self, db: &mut DB) -> Result {
 		ImplicationChainEncoder::default()._encode(db, &self.consistency())
 	}
 
@@ -915,7 +915,7 @@ impl IntVarOrd {
 			.chain(self.xs.intervals(..))
 			.collect()
 	}
-	pub(crate) fn from_bounds<DB: ClauseDatabase>(
+	pub(crate) fn from_bounds<DB: ClauseDatabase + ?Sized>(
 		db: &mut DB,
 		lb: Coeff,
 		ub: Coeff,
@@ -924,7 +924,11 @@ impl IntVarOrd {
 		Self::from_dom(db, (lb..=ub).collect_vec().as_slice(), lbl)
 	}
 
-	pub(crate) fn from_dom<DB: ClauseDatabase>(db: &mut DB, dom: &[Coeff], lbl: String) -> Self {
+	pub(crate) fn from_dom<DB: ClauseDatabase + ?Sized>(
+		db: &mut DB,
+		dom: &[Coeff],
+		lbl: String,
+	) -> Self {
 		Self::from_syms(
 			db,
 			dom.iter()
@@ -935,7 +939,7 @@ impl IntVarOrd {
 		)
 	}
 
-	pub(crate) fn from_syms<DB: ClauseDatabase>(
+	pub(crate) fn from_syms<DB: ClauseDatabase + ?Sized>(
 		db: &mut DB,
 		syms: IntervalSet<Coeff>,
 		lbl: String,
@@ -943,7 +947,7 @@ impl IntVarOrd {
 		Self::from_views(db, syms.into_iter(..).map(|c| (c, None)).collect(), lbl)
 	}
 
-	pub(crate) fn from_views<DB: ClauseDatabase>(
+	pub(crate) fn from_views<DB: ClauseDatabase + ?Sized>(
 		db: &mut DB,
 		views: IntervalMap<Coeff, Option<Lit>>,
 		lbl: String,
@@ -1244,7 +1248,7 @@ impl Model {
 		var
 	}
 
-	pub(crate) fn encode<DB: ClauseDatabase>(
+	pub(crate) fn encode<DB: ClauseDatabase + ?Sized>(
 		&mut self,
 		db: &mut DB,
 		cutoff: Option<Coeff>,
@@ -1378,7 +1382,7 @@ impl Display for TernLeConstraint<'_> {
 	}
 }
 
-impl<DB: ClauseDatabase> Encoder<DB, TernLeConstraint<'_>> for TernLeEncoder {
+impl<DB: ClauseDatabase + ?Sized> Encoder<DB, TernLeConstraint<'_>> for TernLeEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "tern_le_encoder", skip_all, fields(constraint = format!("{} + {} {} {}", tern.x, tern.y, tern.cmp, tern.z)))
@@ -1827,7 +1831,7 @@ pub(crate) mod tests {
 		assert_eq!(c.geq(45..46), vec![vec![]]);
 	}
 
-	fn get_bin_x<DB: ClauseDatabase>(
+	fn get_bin_x<DB: ClauseDatabase + ?Sized>(
 		db: &mut DB,
 		lb: Coeff,
 		ub: Coeff,
@@ -1841,7 +1845,7 @@ pub(crate) mod tests {
 		IntVarEnc::Bin(x)
 	}
 
-	fn get_ord_x<DB: ClauseDatabase>(
+	fn get_ord_x<DB: ClauseDatabase + ?Sized>(
 		db: &mut DB,
 		dom: IntervalSet<Coeff>,
 		consistent: bool,

--- a/crates/pindakaas/src/lib.rs
+++ b/crates/pindakaas/src/lib.rs
@@ -35,6 +35,7 @@ use std::{
 
 use itertools::{traits::HomogeneousTuple, Itertools};
 
+pub use crate::helpers::AsDynClauseDatabase;
 use crate::{helpers::subscript_number, propositional_logic::Formula, solver::VarFactory};
 
 /// A helper type used to represent a Boolean value that can be either a literal
@@ -111,9 +112,10 @@ pub trait ClauseDatabaseTools: ClauseDatabase {
 		}
 	}
 
-	fn encode<C, E: Encoder<Self, C>>(&mut self, constraint: &C, encoder: &E) -> Result
+	fn encode<C, E>(&mut self, constraint: &C, encoder: &E) -> Result
 	where
-		Self: Sized,
+		C: ?Sized,
+		E: Encoder<Self, C> + ?Sized,
 	{
 		encoder.encode(self, constraint)
 	}
@@ -183,7 +185,7 @@ pub trait ClauseDatabaseTools: ClauseDatabase {
 
 	fn with_conditions(&mut self, conditions: Vec<Lit>) -> impl ClauseDatabase + '_
 	where
-		Self: Sized,
+		Self: AsDynClauseDatabase,
 	{
 		struct ConditionalDatabase<'a> {
 			db: &'a mut dyn ClauseDatabase,
@@ -207,7 +209,7 @@ pub trait ClauseDatabaseTools: ClauseDatabase {
 		}
 
 		ConditionalDatabase {
-			db: self,
+			db: self.as_mut_dyn(),
 			conditions,
 		}
 	}
@@ -244,7 +246,7 @@ enum Dimacs {
 }
 
 /// Encoder is the central trait implemented for all the encoding algorithms
-pub trait Encoder<DB: ClauseDatabase, Constraint> {
+pub trait Encoder<DB: ClauseDatabase + ?Sized, Constraint: ?Sized> {
 	fn encode(&self, db: &mut DB, con: &Constraint) -> Result;
 }
 
@@ -669,7 +671,7 @@ impl<'a> Iterator for CnfIterator<'a> {
 	}
 }
 
-impl<DB> ClauseDatabaseTools for DB where DB: ClauseDatabase + ?Sized {}
+impl<DB: ClauseDatabase + ?Sized> ClauseDatabaseTools for DB {}
 
 impl<F: Fn(Lit) -> bool> Valuation for F {
 	fn value(&self, lit: Lit) -> bool {

--- a/crates/pindakaas/src/propositional_logic.rs
+++ b/crates/pindakaas/src/propositional_logic.rs
@@ -8,7 +8,8 @@ use std::{
 use itertools::{Itertools, Position};
 
 use crate::{
-	BoolVal, ClauseDatabase, ClauseDatabaseTools, Cnf, Encoder, Lit, Result, Unsatisfiable,
+	AsDynClauseDatabase, BoolVal, ClauseDatabase, ClauseDatabaseTools, Cnf, Encoder, Lit, Result,
+	Unsatisfiable,
 };
 
 /// A propositional logic formula
@@ -397,7 +398,7 @@ impl From<Formula<Lit>> for Formula<BoolVal> {
 impl Formula<Lit> {
 	/// Helper function to bind the (sub) formula to a name (literal) for the
 	/// tseitin encoding.
-	fn bind<DB: ClauseDatabase>(&self, db: &mut DB, name: Option<Lit>) -> Result<Lit> {
+	fn bind<DB: ClauseDatabase + ?Sized>(&self, db: &mut DB, name: Option<Lit>) -> Result<Lit> {
 		Ok(match self {
 			Formula::Atom(lit) => {
 				if let Some(name) = name {
@@ -618,7 +619,7 @@ impl BitXor<Lit> for Formula<Lit> {
 	}
 }
 
-impl<DB: ClauseDatabase> Encoder<DB, Formula<BoolVal>> for TseitinEncoder {
+impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, Formula<BoolVal>> for TseitinEncoder {
 	fn encode(&self, db: &mut DB, con: &Formula<BoolVal>) -> Result {
 		match con.clone().resolve() {
 			Err(false) => Err(Unsatisfiable),
@@ -628,7 +629,7 @@ impl<DB: ClauseDatabase> Encoder<DB, Formula<BoolVal>> for TseitinEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase> Encoder<DB, Formula<Lit>> for TseitinEncoder {
+impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, Formula<Lit>> for TseitinEncoder {
 	fn encode(&self, db: &mut DB, f: &Formula<Lit>) -> Result {
 		match f {
 			Formula::Atom(l) => db.add_clause([*l]),

--- a/crates/pindakaas/src/sorted.rs
+++ b/crates/pindakaas/src/sorted.rs
@@ -76,7 +76,7 @@ impl Checker for Sorted<'_> {
 	}
 }
 
-impl<DB: ClauseDatabase> Encoder<DB, Sorted<'_>> for SortedEncoder {
+impl<DB: ClauseDatabase + ?Sized> Encoder<DB, Sorted<'_>> for SortedEncoder {
 	fn encode(&self, db: &mut DB, sorted: &Sorted) -> Result {
 		let xs = sorted
 			.xs
@@ -97,7 +97,7 @@ impl<DB: ClauseDatabase> Encoder<DB, Sorted<'_>> for SortedEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase> Encoder<DB, TernLeConstraint<'_>> for SortedEncoder {
+impl<DB: ClauseDatabase + ?Sized> Encoder<DB, TernLeConstraint<'_>> for SortedEncoder {
 	fn encode(&self, db: &mut DB, tern: &TernLeConstraint) -> Result {
 		let TernLeConstraint { x, y, cmp, z } = tern;
 		if tern.is_fixed()? {
@@ -134,7 +134,12 @@ impl SortedEncoder {
 		self.overwrite_recursive_cmp = cmp;
 		self
 	}
-	fn next_int_var<DB: ClauseDatabase>(&self, db: &mut DB, ub: Coeff, lbl: String) -> IntVarEnc {
+	fn next_int_var<DB: ClauseDatabase + ?Sized>(
+		&self,
+		db: &mut DB,
+		ub: Coeff,
+		lbl: String,
+	) -> IntVarEnc {
 		// TODO We always have the view x>=1 <-> y>=1, which is now realized using equiv
 		if ub == 0 {
 			IntVarEnc::Const(0)
@@ -148,7 +153,7 @@ impl SortedEncoder {
 	}
 
 	/// The sorted/merged base case of x1{0,1}+x2{0,1}<=y{0,1,2}
-	fn smerge<DB: ClauseDatabase>(
+	fn smerge<DB: ClauseDatabase + ?Sized>(
 		&self,
 		db: &mut DB,
 		x1: &IntVarEnc,
@@ -174,7 +179,7 @@ impl SortedEncoder {
 		self.comp(db, x1, &x2, cmp, &y, 1)
 	}
 
-	fn sorted<DB: ClauseDatabase>(
+	fn sorted<DB: ClauseDatabase + ?Sized>(
 		&self,
 		db: &mut DB,
 		xs: &[IntVarEnc],
@@ -258,7 +263,7 @@ impl SortedEncoder {
 		}
 	}
 
-	fn sort<DB: ClauseDatabase>(
+	fn sort<DB: ClauseDatabase + ?Sized>(
 		&self,
 		db: &mut DB,
 		xs: &[IntVarEnc],
@@ -278,7 +283,7 @@ impl SortedEncoder {
 		}
 	}
 
-	fn merged<DB: ClauseDatabase>(
+	fn merged<DB: ClauseDatabase + ?Sized>(
 		&self,
 		db: &mut DB,
 		x1: &IntVarEnc,
@@ -361,7 +366,7 @@ impl SortedEncoder {
 		}
 	}
 
-	fn comp<DB: ClauseDatabase>(
+	fn comp<DB: ClauseDatabase + ?Sized>(
 		&self,
 		db: &mut DB,
 		x: &IntVarEnc,


### PR DESCRIPTION
This allows the more liberal usage of non-sized and `dyn` objects of
ClauseDatabase. We introduce the `AsDynClauseDatabase` for placed where
we need to be able to create a `dyn ClauseDatabase` references. This
trait is automatically implemented for all `Sized` types and `dyn`
references, but cannot be automatically implemented for `?Sized` types.
