### PR TITLE
Proof Logging Interface for CaDiCaL

### DIFF
--- a/crates/pindakaas-cadical/build.rs
+++ b/crates/pindakaas-cadical/build.rs
@@ -37,6 +37,7 @@ fn main() {
 		"vendor/cadical/src/format.cpp",
 		"vendor/cadical/src/frattracer.cpp",
 		"vendor/cadical/src/gates.cpp",
+		"vendor/cadical/src/huubtracer.cpp",
 		"vendor/cadical/src/idruptracer.cpp",
 		"vendor/cadical/src/instantiate.cpp",
 		"vendor/cadical/src/internal.cpp",

--- a/crates/pindakaas-cadical/src/ccadical_override.cpp
+++ b/crates/pindakaas-cadical/src/ccadical_override.cpp
@@ -64,5 +64,8 @@ void ccadical_phase(CCaDiCaL *slv, int lit) {
 void ccadical_unphase(CCaDiCaL *slv, int lit) {
   ((Wrapper *)slv)->solver->unphase(lit);
 }
-
+void ccadical_enable_proof(CCaDiCaL *slv, const char* name) {
+  FILE* file = fopen(name, "a");
+  ((Wrapper *)slv)->solver->trace_proof(file, name);
+}
 }

--- a/crates/pindakaas-cadical/src/ccadical_override.cpp
+++ b/crates/pindakaas-cadical/src/ccadical_override.cpp
@@ -65,7 +65,10 @@ void ccadical_unphase(CCaDiCaL *slv, int lit) {
   ((Wrapper *)slv)->solver->unphase(lit);
 }
 void ccadical_enable_proof(CCaDiCaL *slv, const char* name) {
-  FILE* file = fopen(name, "a");
-  ((Wrapper *)slv)->solver->trace_proof(file, name);
+  // Enable proof tracing
+  ((Wrapper *)slv)->solver->trace_proof(name);
+   // Custom solver method needed to print the 
+   // `pseudo-Boolean proof version 2.0` header.
+  ((Wrapper *)slv)->solver->begin_proof(0);
 }
 }

--- a/crates/pindakaas-cadical/src/ccadical_override.h
+++ b/crates/pindakaas-cadical/src/ccadical_override.h
@@ -45,6 +45,8 @@ bool ccadical_is_observed(CCaDiCaL *, int lit);
 void ccadical_phase(CCaDiCaL *, int lit);
 void ccadical_unphase(CCaDiCaL *, int lit);
 
+// Will add additional proof logging functions here.
+
 /*------------------------------------------------------------------------*/
 
 /*------------------------------------------------------------------------*/

--- a/crates/pindakaas-cadical/src/ccadical_override.h
+++ b/crates/pindakaas-cadical/src/ccadical_override.h
@@ -44,8 +44,7 @@ CCaDiCaL *ccadical_copy(CCaDiCaL *slv);
 bool ccadical_is_observed(CCaDiCaL *, int lit);
 void ccadical_phase(CCaDiCaL *, int lit);
 void ccadical_unphase(CCaDiCaL *, int lit);
-
-// Will add additional proof logging functions here.
+void ccadical_enable_proof (CCaDiCaL *, const char *);
 
 /*------------------------------------------------------------------------*/
 

--- a/crates/pindakaas-cadical/src/lib.rs
+++ b/crates/pindakaas-cadical/src/lib.rs
@@ -26,4 +26,5 @@ extern "C" {
 	pub fn ccadical_simplify(slv: *mut c_void) -> c_int;
 	pub fn ccadical_terminate(slv: *mut c_void);
 	pub fn ccadical_unphase(slv: *mut c_void, lit: i32);
+	pub fn ccadical_enable_proof(slv: *mut c_void, name: *const c_char);
 }

--- a/crates/pindakaas/src/solver/cadical.rs
+++ b/crates/pindakaas/src/solver/cadical.rs
@@ -67,6 +67,8 @@ impl Cadical {
 
 	pub fn enable_proof(&mut self, name: &str) {
 		let name = CString::new(name).unwrap();
+		// SAFETY: Pointer is known to be valid, CaDiCaL's file API should handle
+		// all possible name paths.
 		unsafe {
 			ccadical_enable_proof(self.ptr, name.as_ptr());
 		}

--- a/crates/pindakaas/src/solver/cadical.rs
+++ b/crates/pindakaas/src/solver/cadical.rs
@@ -3,7 +3,7 @@ use std::{
 	fmt,
 };
 
-use pindakaas_cadical::{ccadical_copy, ccadical_phase, ccadical_unphase};
+use pindakaas_cadical::{ccadical_copy, ccadical_enable_proof, ccadical_phase, ccadical_unphase};
 use pindakaas_derive::IpasirSolver;
 
 use crate::{solver::FFIPointer, Lit, VarFactory};
@@ -63,6 +63,13 @@ impl Cadical {
 	pub fn unphase(&mut self, lit: Lit) {
 		// SAFETY: Pointer known to be non-null, no other known safety concerns.
 		unsafe { ccadical_unphase(self.ptr, lit.0.get()) }
+	}
+
+	pub fn enable_proof(&mut self, name: &str) {
+		let name = CString::new(name).unwrap();
+		unsafe {
+			ccadical_enable_proof(self.ptr, name.as_ptr());
+		}
 	}
 }
 


### PR DESCRIPTION
Update the CaDiCaL Rust bindings to give the option to enable the new huub_tracer (see pindakaashq/cadical#1).