### PR TITLE
Upgrade maturin

### DIFF
--- a/crates/pyndakaas/pyproject.toml
+++ b/crates/pyndakaas/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.11,<0.12"]
+requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
Otherwise, the dynamic workspace fails for me with:

```
> pip install .
  [..]
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      💥 maturin failed
        Caused by: Failed to parse Cargo.toml at Cargo.toml
        Caused by: invalid type: map, expected a sequence for key `package.authors` at line 5 column 21
```