### PR TITLE
Implement `__radd__` to support `2+x` or `sum([x,y,z])`

### DIFF
--- a/crates/pyndakaas/python/pindakaas/__init__.py
+++ b/crates/pyndakaas/python/pindakaas/__init__.py
@@ -1,7 +1,7 @@
 import pindakaas.solver
 
 from .encoding import CNF, WCNF, ClauseDatabase, Constraint
-from .pindakaas import Formula, Lit, Encoder
+from .pindakaas import Formula, Lit, Encoder, BoolLinExp
 
 __doc__ = pindakaas.__doc__
 __all__ = ["Constraint", "ClauseDatabase", "CNF", "Encoder", "Formula", "Lit", "WCNF"]

--- a/crates/pyndakaas/python/pindakaas/__init__.py
+++ b/crates/pyndakaas/python/pindakaas/__init__.py
@@ -1,7 +1,7 @@
 import pindakaas.solver
 
 from .encoding import CNF, WCNF, ClauseDatabase, Constraint
-from .pindakaas import Formula, Lit, Encoder, BoolLinExp
+from .pindakaas import Formula, Lit, Encoder
 
 __doc__ = pindakaas.__doc__
 __all__ = ["Constraint", "ClauseDatabase", "CNF", "Encoder", "Formula", "Lit", "WCNF"]

--- a/crates/pyndakaas/python/tests/test_modelling.py
+++ b/crates/pyndakaas/python/tests/test_modelling.py
@@ -4,10 +4,12 @@ import pindakaas
 def test_bool_lin():
     f = pindakaas.CNF()
     x, y, z = f.new_vars(3)
-    assert str(x + 2) == "x₁ + 2"
-    assert str(2 + x) == "x₁ + 2"
-    c = x + y - z + 2
-    assert str(c) == "-x₃ + x₂ + x₁ + 2"
+    assert str(x + 2) == "x₁ + 2", "__add__ incorrect"
+    assert str(2 + x) == "x₁ + 2", "__radd__ incorrect"
+    assert str(x - 2) == "x₁ + -2", "__sub__ incorrect"
+    assert str(2 * x) == "2*x₁", "__mul__ incorrect"
+    assert str(x * 2) == "2*x₁", "__rmul__ incorrect"
+    assert str(x + y - z + 2) == "-x₃ + x₂ + x₁ + 2"
     c = sum([x, y, z])
     assert str(c) == "x₃ + x₂ + x₁"
     c *= 2
@@ -21,16 +23,33 @@ def test_bool_lin():
     assert str(d) == "x₃ + x₂ + x₁ >= 2"
 
 
-def test_lit_ops():
+def test_formula_ops():
     f = pindakaas.CNF()
     x, y, z = f.new_vars(3)
-    a = ~x | ~y
-    assert str(a) == "¬x₁ ∨ ¬x₂"
-    b = y & z
-    assert str(b) == "x₂ ∧ x₃"
-    c = x ^ y
-    assert str(c) == "x₁ ⊻ x₂"
-    d = x ^ True
-    assert str(d) == "x₁ ⊻ true"
-    e = x == y
-    assert str(e) == "x₁ ≡ x₂"
+    f = x & y
+    g = x | z
+    assert str(f & True) == "x₁ ∧ x₂ ∧ true", "__and__ incorrect"
+    assert str(True & f) == "x₁ ∧ x₂ ∧ true", "__rand__ incorrect"
+    assert str(f & g) == "x₁ ∧ x₂ ∧ (x₁ ∨ x₃)", "__and__ incorrect"
+    assert str(f | True) == "(x₁ ∧ x₂) ∨ true", "__or__ incorrect"
+    assert str(True | f) == "(x₁ ∧ x₂) ∨ true", "__ror__ incorrect"
+    assert str(f | g) == "x₁ ∨ x₃ ∨ (x₁ ∧ x₂)", "__or__ incorrect"
+    assert str(f ^ True) == "(x₁ ∧ x₂) ⊻ true", "__xor__ incorrect"
+    assert str(True ^ f) == "(x₁ ∧ x₂) ⊻ true", "__rxor__ incorrect"
+    assert str(f ^ g) == "(x₁ ∧ x₂) ⊻ (x₁ ∨ x₃)", "__xor__ incorrect"
+
+
+def test_lit_ops():
+    f = pindakaas.CNF()
+    x, y = f.new_vars(2)
+    assert str(x & True) == "x₁ ∧ true", "__and__ incorrect"
+    assert str(True & x) == "x₁ ∧ true", "__rand__ incorrect"
+    assert str(x | True) == "x₁ ∨ true", "__or__ incorrect"
+    assert str(True | x) == "x₁ ∨ true", "__ror__ incorrect"
+    assert str(x ^ True) == "x₁ ⊻ true", "__xor__ incorrect"
+    assert str(True ^ x) == "x₁ ⊻ true", "__rxor__ incorrect"
+    assert str(~x | ~y) == "¬x₁ ∨ ¬x₂"
+    assert str(x & y) == "x₁ ∧ x₂"
+    assert str(x ^ y) == "x₁ ⊻ x₂"
+    assert str(x == y) == "x₁ ≡ x₂"
+

--- a/crates/pyndakaas/python/tests/test_modelling.py
+++ b/crates/pyndakaas/python/tests/test_modelling.py
@@ -4,14 +4,14 @@ import pindakaas
 def test_bool_lin():
     f = pindakaas.CNF()
     x, y, z = f.new_vars(3)
+    assert str(x + 2) == "x₁ + 2"
+    assert str(2 + x) == "x₁ + 2"
     c = x + y - z + 2
     assert str(c) == "-x₃ + x₂ + x₁ + 2"
-    c = sum([x, y, z], pindakaas.BoolLinExp())
+    c = sum([x, y, z])
     assert str(c) == "x₃ + x₂ + x₁"
-    c = sum([y, y, z], x)
-    assert str(c) == "x₃ + x₂ + x₂ + x₁"
     c *= 2
-    assert str(c) == "2*x₃ + 2*x₂ + 2*x₂ + 2*x₁"
+    assert str(c) == "2*x₃ + 2*x₂ + 2*x₁"
     c = x + y + z
     d = c == 2
     assert str(d) == "x₃ + x₂ + x₁ == 2"

--- a/crates/pyndakaas/python/tests/test_modelling.py
+++ b/crates/pyndakaas/python/tests/test_modelling.py
@@ -22,6 +22,16 @@ def test_bool_lin():
     d = c >= 2
     assert str(d) == "x₃ + x₂ + x₁ >= 2"
 
+def test_bool_lin_ops():
+    f = pindakaas.CNF()
+    x, y, z = f.new_vars(3)
+    f = x + y
+    g = x - z
+    assert str(f + 2) == "x₂ + x₁ + 2", "__add__ incorrect"
+    assert str(2 + f) == "x₂ + x₁ + 2", "__radd__ incorrect"
+    assert str(f + g) == "-x₃ + x₁ + x₂ + x₁", "__add__ incorrect"
+    assert str(f * 2) == "2*x₂ + 2*x₁", "__mul__ incorrect"
+    assert str(2 * f) == "2*x₂ + 2*x₁", "__rmul__ incorrect"
 
 def test_formula_ops():
     f = pindakaas.CNF()
@@ -37,7 +47,6 @@ def test_formula_ops():
     assert str(f ^ True) == "(x₁ ∧ x₂) ⊻ true", "__xor__ incorrect"
     assert str(True ^ f) == "(x₁ ∧ x₂) ⊻ true", "__rxor__ incorrect"
     assert str(f ^ g) == "(x₁ ∧ x₂) ⊻ (x₁ ∨ x₃)", "__xor__ incorrect"
-
 
 def test_lit_ops():
     f = pindakaas.CNF()

--- a/crates/pyndakaas/python/tests/test_modelling.py
+++ b/crates/pyndakaas/python/tests/test_modelling.py
@@ -6,6 +6,8 @@ def test_bool_lin():
     x, y, z = f.new_vars(3)
     c = x + y - z + 2
     assert str(c) == "-x₃ + x₂ + x₁ + 2"
+    c = sum([x, y, z], pindakaas.BoolLinExp())
+    assert str(c) == "x₃ + x₂ + x₁"
     c = sum([y, y, z], x)
     assert str(c) == "x₃ + x₂ + x₂ + x₁"
     c *= 2

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -218,6 +218,11 @@ mod pindakaas {
 
 	#[pymethods]
 	impl BoolLinExp {
+		#[new]
+		fn new() -> Self {
+			Self(Default::default())
+		}
+
 		fn __add__(&self, other: BoolLinArg) -> Self {
 			let mut res = self.clone();
 			res.__iadd__(other);

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -412,6 +412,10 @@ mod pindakaas {
 			self.as_bool_lin_exp().__add__(other)
 		}
 
+		fn __radd__(&self, other: i64) -> BoolLinExp {
+			self.as_bool_lin_exp().__add__(BoolLinArg::Int(other))
+		}
+
 		fn __and__(&self, other: FormulaArg) -> Formula {
 			Formula(self.as_formula()).__and__(other)
 		}

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -224,6 +224,10 @@ mod pindakaas {
 			res
 		}
 
+		fn __radd__(&self, other: BoolLinArg) -> Self {
+			self.__add__(other)
+		}
+
 		fn __eq__(&self, other: i64) -> BoolLinCon {
 			BoolLinCon(BaseBoolLinCon::new(
 				self.0.clone(),
@@ -272,6 +276,10 @@ mod pindakaas {
 			let mut res = self.clone();
 			res.__imul__(other);
 			res
+		}
+
+		fn __rmul__(&self, other: i64) -> Self {
+			self.__mul__(other)
 		}
 
 		fn __neg__(&self) -> Self {

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -218,11 +218,6 @@ mod pindakaas {
 
 	#[pymethods]
 	impl BoolLinExp {
-		#[new]
-		fn new() -> Self {
-			Self(Default::default())
-		}
-
 		fn __add__(&self, other: BoolLinArg) -> Self {
 			let mut res = self.clone();
 			res.__iadd__(other);

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -330,6 +330,10 @@ mod pindakaas {
 			Self(self.0.clone() & other.as_formula())
 		}
 
+		fn __rand__(&self, other: FormulaArg) -> Self {
+			self.__and__(other)
+		}
+
 		fn __eq__(&self, other: FormulaArg) -> Self {
 			use BaseFormula::*;
 
@@ -368,12 +372,20 @@ mod pindakaas {
 			Formula(self.0.clone() | other.as_formula())
 		}
 
+		fn __ror__(&self, other: FormulaArg) -> Self {
+			self.__or__(other)
+		}
+
 		fn __str__(&self) -> String {
 			self.0.to_string()
 		}
 
 		fn __xor__(&self, other: FormulaArg) -> Self {
 			Formula(self.0.clone() ^ other.as_formula())
+		}
+
+		fn __rxor__(&self, other: FormulaArg) -> Self {
+			self.__xor__(other)
 		}
 	}
 
@@ -407,11 +419,15 @@ mod pindakaas {
 			self.as_bool_lin_exp().__add__(other)
 		}
 
-		fn __radd__(&self, other: i64) -> BoolLinExp {
-			self.as_bool_lin_exp().__add__(BoolLinArg::Int(other))
+		fn __radd__(&self, other: BoolLinArg) -> BoolLinExp {
+			self.__add__(other)
 		}
 
 		fn __and__(&self, other: FormulaArg) -> Formula {
+			Formula(self.as_formula()).__and__(other)
+		}
+
+		fn __rand__(&self, other: FormulaArg) -> Formula {
 			Formula(self.as_formula()).__and__(other)
 		}
 
@@ -447,12 +463,20 @@ mod pindakaas {
 			self.as_bool_lin_exp().__mul__(other)
 		}
 
+		fn __rmul__(&self, other: i64) -> BoolLinExp {
+			self.__mul__(other)
+		}
+
 		fn __ne__(&self, other: FormulaArg) -> Formula {
 			Formula(self.as_formula()).__ne__(other)
 		}
 
 		fn __or__(&self, other: FormulaArg) -> Formula {
 			Formula(self.as_formula()).__or__(other)
+		}
+
+		fn __ror__(&self, other: FormulaArg) -> Formula {
+			self.__or__(other)
 		}
 
 		fn __str__(&self) -> String {
@@ -465,6 +489,10 @@ mod pindakaas {
 
 		fn __xor__(&self, other: FormulaArg) -> Formula {
 			Formula(self.as_formula()).__xor__(other)
+		}
+
+		fn __rxor__(&self, other: FormulaArg) -> Formula {
+			self.__xor__(other)
 		}
 
 		pub fn is_negated(&self) -> bool {


### PR DESCRIPTION
Implement `__radd__`  for `Lit` and `BoolLinExp` in order to make `2+x` or `sum([x,y,z])` (without start argument) work. See see https://docs.python.org/3/reference/datamodel.html#object.__radd__. If we add this, we should also implement this for the remaining types and dunder methods.