### PR TITLE
Export exceptions so users can catch them

### DIFF
--- a/crates/pyndakaas/python/pindakaas/__init__.py
+++ b/crates/pyndakaas/python/pindakaas/__init__.py
@@ -1,7 +1,7 @@
 import pindakaas.solver
 
 from .encoding import CNF, WCNF, ClauseDatabase, Constraint
-from .pindakaas import Formula, Lit, Encoder
+from .pindakaas import Formula, Lit, Encoder, Unsatisfiable, InvalidEncoder
 
 __doc__ = pindakaas.__doc__
 __all__ = ["Constraint", "ClauseDatabase", "CNF", "Encoder", "Formula", "Lit", "WCNF"]

--- a/crates/pyndakaas/python/pindakaas/__init__.py
+++ b/crates/pyndakaas/python/pindakaas/__init__.py
@@ -4,4 +4,14 @@ from .encoding import CNF, WCNF, ClauseDatabase, Constraint
 from .pindakaas import Formula, Lit, Encoder, Unsatisfiable, InvalidEncoder
 
 __doc__ = pindakaas.__doc__
-__all__ = ["Constraint", "ClauseDatabase", "CNF", "Encoder", "Formula", "Lit", "WCNF"]
+__all__ = [
+    "Constraint",
+    "ClauseDatabase",
+    "CNF",
+    "Encoder",
+    "Formula",
+    "Lit",
+    "WCNF",
+    "Unsatisfiable",
+    "InvalidEncoder",
+]


### PR DESCRIPTION
 Otherwise, the user cannot encode potentially unsatisfiable constraints by using `try: ... except pindakaas.Unsatisfiable:`?