### PR TITLE
Add conditions argument

### DIFF
--- a/crates/pyndakaas/python/pindakaas/encoding.py
+++ b/crates/pyndakaas/python/pindakaas/encoding.py
@@ -8,7 +8,7 @@ Constraint: TypeAlias = Formula
 
 class ClauseDatabase(ABC):
     def __iadd__(self, constraint: Constraint):
-        self.add_encoding(constraint, None)
+        self.add_encoding(constraint, None, [])
         return self
 
     @abstractmethod
@@ -16,7 +16,10 @@ class ClauseDatabase(ABC):
 
     @abstractmethod
     def add_encoding(
-        self, constraint: Constraint, encoder: Optional[Encoder] = None
+        self,
+        constraint: Constraint,
+        encoder: Optional[Encoder] = None,
+        conditions: Optional[Iterable[Lit]] = [],
     ): ...
 
     def new_var(self):
@@ -35,8 +38,13 @@ class CNF(ClauseDatabase):
     def add_clause(self, clause: Iterable[Lit]):
         return self._inner.add_clause(iter(clause))
 
-    def add_encoding(self, constraint: Constraint, encoder: Optional[Encoder] = None):
-        return self._inner.add_encoding(constraint, encoder)
+    def add_encoding(
+        self,
+        constraint: Constraint,
+        encoder: Optional[Encoder] = None,
+        conditions: Optional[Iterable[Lit]] = [],
+    ):
+        return self._inner.add_encoding(constraint, encoder, conditions)
 
     def new_vars(self, num: int) -> Iterable[Lit]:
         return self._inner.new_vars(num)

--- a/crates/pyndakaas/python/pindakaas/encoding.py
+++ b/crates/pyndakaas/python/pindakaas/encoding.py
@@ -19,7 +19,7 @@ class ClauseDatabase(ABC):
         self,
         constraint: Constraint,
         encoder: Optional[Encoder] = None,
-        conditions: Iterable[Lit] = [],
+        conditions: Optional[Iterable[Lit]] = None,
     ): ...
 
     def new_var(self):
@@ -42,8 +42,9 @@ class CNF(ClauseDatabase):
         self,
         constraint: Constraint,
         encoder: Optional[Encoder] = None,
-        conditions: Iterable[Lit] = [],
+        conditions: Optional[Iterable[Lit]] = None,
     ):
+        conditions = list(conditions) if conditions is not None else []
         return self._inner.add_encoding(constraint, encoder, conditions)
 
     def new_vars(self, num: int) -> Iterable[Lit]:

--- a/crates/pyndakaas/python/pindakaas/encoding.py
+++ b/crates/pyndakaas/python/pindakaas/encoding.py
@@ -19,7 +19,7 @@ class ClauseDatabase(ABC):
         self,
         constraint: Constraint,
         encoder: Optional[Encoder] = None,
-        conditions: Optional[Iterable[Lit]] = None,
+        conditions: Iterable[Lit] = [],
     ): ...
 
     def new_var(self):
@@ -42,7 +42,7 @@ class CNF(ClauseDatabase):
         self,
         constraint: Constraint,
         encoder: Optional[Encoder] = None,
-        conditions: Optional[Iterable[Lit]] = None,
+        conditions: Iterable[Lit] = [],
     ):
         return self._inner.add_encoding(constraint, encoder, conditions)
 

--- a/crates/pyndakaas/python/pindakaas/encoding.py
+++ b/crates/pyndakaas/python/pindakaas/encoding.py
@@ -8,7 +8,7 @@ Constraint: TypeAlias = Formula
 
 class ClauseDatabase(ABC):
     def __iadd__(self, constraint: Constraint):
-        self.add_encoding(constraint, None, [])
+        self.add_encoding(constraint)
         return self
 
     @abstractmethod
@@ -19,7 +19,7 @@ class ClauseDatabase(ABC):
         self,
         constraint: Constraint,
         encoder: Optional[Encoder] = None,
-        conditions: Optional[Iterable[Lit]] = [],
+        conditions: Optional[Iterable[Lit]] = None,
     ): ...
 
     def new_var(self):
@@ -42,7 +42,7 @@ class CNF(ClauseDatabase):
         self,
         constraint: Constraint,
         encoder: Optional[Encoder] = None,
-        conditions: Optional[Iterable[Lit]] = [],
+        conditions: Optional[Iterable[Lit]] = None,
     ):
         return self._inner.add_encoding(constraint, encoder, conditions)
 

--- a/crates/pyndakaas/python/pindakaas/solver.py
+++ b/crates/pyndakaas/python/pindakaas/solver.py
@@ -30,7 +30,9 @@ class Solver(ClauseDatabase):
 
     @contextmanager
     def solve(
-        self, assumptions: Optional[Iterable[Lit]] = None, time_limit: Optional[timedelta] = None
+        self,
+        assumptions: Optional[Iterable[Lit]] = None,
+        time_limit: Optional[timedelta] = None,
     ) -> Iterator[Result]:
         self._set_time_limit(time_limit)
         assumptions = assumptions if assumptions is not None else []
@@ -59,8 +61,8 @@ class CaDiCaL(Solver):
     def add_clause(self, clause: Iterable[Lit]):
         return self._inner.add_clause(iter(clause))
 
-    def add_encoding(self, constraint: Constraint, encoder: Optional[Encoder] = None):
-        return self._inner.add_encoding(constraint, encoder)
+    def add_encoding(self, constraint: Constraint, encoder: Optional[Encoder] = None, conditions: Optional[Iterable[Lit]] = []):
+        return self._inner.add_encoding(constraint, encoder, conditions)
 
     def new_vars(self, num: int):
         return self._inner.new_vars(num)

--- a/crates/pyndakaas/python/pindakaas/solver.py
+++ b/crates/pyndakaas/python/pindakaas/solver.py
@@ -61,7 +61,13 @@ class CaDiCaL(Solver):
     def add_clause(self, clause: Iterable[Lit]):
         return self._inner.add_clause(iter(clause))
 
-    def add_encoding(self, constraint: Constraint, encoder: Optional[Encoder] = None, conditions: Optional[Iterable[Lit]] = []):
+    def add_encoding(
+        self,
+        constraint: Constraint,
+        encoder: Optional[Encoder] = None,
+        conditions: Optional[Iterable[Lit]] = None,
+    ):
+        conditions = list(conditions) if conditions is not None else []
         return self._inner.add_encoding(constraint, encoder, conditions)
 
     def new_vars(self, num: int):

--- a/crates/pyndakaas/python/tests/test_encoding.py
+++ b/crates/pyndakaas/python/tests/test_encoding.py
@@ -51,3 +51,10 @@ def test_wcnf():
     f.add_weighted_clause([x], 1)
     f.add_weighted_clause([y], 2)
     assert f.to_dimacs() == "p wcnf 2 3 4\n4 1 2 0\n1 1 0\n2 2 0\n"
+
+def test_conditions():
+    f = pindakaas.CNF()
+    x, y, p = f.new_vars(3)
+    f.add_encoding(x ^ y, conditions=[p])
+    assert f.to_dimacs() == ""
+

--- a/crates/pyndakaas/python/tests/test_encoding.py
+++ b/crates/pyndakaas/python/tests/test_encoding.py
@@ -56,5 +56,5 @@ def test_conditions():
     f = pindakaas.CNF()
     x, y, p = f.new_vars(3)
     f.add_encoding(x ^ y, conditions=[p])
-    assert f.to_dimacs() == ""
+    assert f.to_dimacs() == "p cnf 3 2\n3 1 2 0\n3 -1 -2 0\n"
 

--- a/crates/pyndakaas/python/tests/test_encoding.py
+++ b/crates/pyndakaas/python/tests/test_encoding.py
@@ -73,6 +73,7 @@ def test_wcnf():
     f.add_weighted_clause([y], 2)
     assert f.to_dimacs() == "p wcnf 2 3 4\n4 1 2 0\n1 1 0\n2 2 0\n"
 
+
 def test_conditions():
     f = pindakaas.CNF()
     x, y, p = f.new_vars(3)

--- a/crates/pyndakaas/python/tests/test_encoding.py
+++ b/crates/pyndakaas/python/tests/test_encoding.py
@@ -57,4 +57,3 @@ def test_conditions():
     x, y, p = f.new_vars(3)
     f.add_encoding(x ^ y, conditions=[p])
     assert f.to_dimacs() == "p cnf 3 2\n3 1 2 0\n3 -1 -2 0\n"
-

--- a/crates/pyndakaas/python/tests/test_modelling.py
+++ b/crates/pyndakaas/python/tests/test_modelling.py
@@ -22,6 +22,7 @@ def test_bool_lin():
     d = c >= 2
     assert str(d) == "x₃ + x₂ + x₁ >= 2"
 
+
 def test_bool_lin_ops():
     f = pindakaas.CNF()
     x, y, z = f.new_vars(3)
@@ -32,6 +33,7 @@ def test_bool_lin_ops():
     assert str(f + g) == "-x₃ + x₁ + x₂ + x₁", "__add__ incorrect"
     assert str(f * 2) == "2*x₂ + 2*x₁", "__mul__ incorrect"
     assert str(2 * f) == "2*x₂ + 2*x₁", "__rmul__ incorrect"
+
 
 def test_formula_ops():
     f = pindakaas.CNF()
@@ -47,6 +49,7 @@ def test_formula_ops():
     assert str(f ^ True) == "(x₁ ∧ x₂) ⊻ true", "__xor__ incorrect"
     assert str(True ^ f) == "(x₁ ∧ x₂) ⊻ true", "__rxor__ incorrect"
     assert str(f ^ g) == "(x₁ ∧ x₂) ⊻ (x₁ ∨ x₃)", "__xor__ incorrect"
+
 
 def test_lit_ops():
     f = pindakaas.CNF()

--- a/crates/pyndakaas/python/tests/test_modelling.py
+++ b/crates/pyndakaas/python/tests/test_modelling.py
@@ -32,3 +32,4 @@ def test_lit_ops():
     assert str(d) == "x₁ ⊻ true"
     e = x == y
     assert str(e) == "x₁ ≡ x₂"
+

--- a/crates/pyndakaas/python/tests/test_solving.py
+++ b/crates/pyndakaas/python/tests/test_solving.py
@@ -12,3 +12,18 @@ def test_cadical():
         assert vx is not None
         assert vy is not None
         assert vx != vy
+
+def test_assumptions():
+    slv = pindakaas.solver.CaDiCaL()
+    x, y = slv.new_vars(2)
+    slv += x ^ y
+    with slv.solve(assumptions=[x]) as result:
+        assert result.status == pindakaas.solver.Status.SATISFIED
+        assert result.value(x) is True
+        assert result.value(y) is False
+    with slv.solve(assumptions=[y]) as result:
+        assert result.status == pindakaas.solver.Status.SATISFIED
+        assert result.value(x) is False
+        assert result.value(y) is True
+    with slv.solve(assumptions=[x, y]) as result:
+        assert result.status == pindakaas.solver.Status.UNSATISFIABLE

--- a/crates/pyndakaas/python/tests/test_solving.py
+++ b/crates/pyndakaas/python/tests/test_solving.py
@@ -13,6 +13,7 @@ def test_cadical():
         assert vy is not None
         assert vx != vy
 
+
 def test_assumptions():
     slv = pindakaas.solver.CaDiCaL()
     x, y = slv.new_vars(2)

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -126,22 +126,32 @@ mod pindakaas {
 	/// associated weights.
 	struct WCNFInner(Wcnf);
 
+	/// Same `encode_constraint`, but evaluates the conditions if not empty. This prevents
+	/// costly virtual method access if this were done inside `encode_constraint`
+	fn encode_constraint_with_conditions<Db: ClauseDatabase>(
+		db: &mut Db,
+		con: ConstraintArg,
+		enc: Option<Encoder>,
+		conditions: Vec<Lit>,
+	) -> PyResult<()> {
+		if conditions.is_empty() {
+			encode_constraint(db, con, enc)
+		} else {
+			encode_constraint(
+				&mut db.with_conditions(conditions.into_iter().map(|l| l.0).collect()),
+				con,
+				enc,
+			)
+		}
+	}
+
 	/// Internal function to help with the encoding of a constraint given an
 	/// optional encoder.
 	fn encode_constraint<Db: ClauseDatabase>(
 		db: &mut Db,
 		con: ConstraintArg,
 		enc: Option<Encoder>,
-		conditions: Vec<Lit>,
 	) -> PyResult<()> {
-		if !conditions.is_empty() {
-			return encode_constraint(
-				&mut db.with_conditions(conditions.into_iter().map(|l| l.0).collect()),
-				con,
-				enc,
-				Vec::new(),
-			);
-		}
 		let invalid_enc = |con_ty, enc| {
 			Err(InvalidEncoder::new_err(format!(
 				"unable to encode `{con_ty}' using {enc:?}"
@@ -317,7 +327,7 @@ mod pindakaas {
 			enc: Option<Encoder>,
 			conditions: Vec<Lit>,
 		) -> PyResult<()> {
-			encode_constraint(&mut self.0, con, enc, conditions)
+			encode_constraint_with_conditions(&mut self.0, con, enc, conditions)
 		}
 
 		#[new]
@@ -511,7 +521,7 @@ mod pindakaas {
 			enc: Option<Encoder>,
 			conditions: Vec<Lit>,
 		) -> PyResult<()> {
-			encode_constraint(&mut self.0, con, enc, conditions)
+			encode_constraint_with_conditions(&mut self.0, con, enc, conditions)
 		}
 
 		fn add_weighted_clause(
@@ -564,7 +574,8 @@ mod pindakaas {
 		};
 		use pyo3::{prelude::*, types::PyIterator};
 
-		use crate::pindakaas::{encode_constraint, ConstraintArg, Encoder, Lit};
+		use super::encode_constraint_with_conditions;
+		use crate::pindakaas::{ConstraintArg, Encoder, Lit};
 
 		#[pyclass]
 		#[derive(Debug, Default)]
@@ -624,7 +635,7 @@ mod pindakaas {
 				conditions: Vec<Lit>,
 			) -> PyResult<()> {
 				let mut guard = self.0.lock().unwrap();
-				encode_constraint(&mut *guard, con, enc, conditions)
+				encode_constraint_with_conditions(&mut *guard, con, enc, conditions)
 			}
 
 			#[new]

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -132,6 +132,7 @@ mod pindakaas {
 		db: &mut Db,
 		con: ConstraintArg,
 		enc: Option<Encoder>,
+		conditions: Vec<Lit>,
 	) -> PyResult<()> {
 		let invalid_enc = |con_ty, enc| {
 			Err(InvalidEncoder::new_err(format!(
@@ -141,6 +142,7 @@ mod pindakaas {
 		let map_unsat = |_err| {
 			Unsatisfiable::new_err("constraint was found to be unsatisfiable during encoding")
 		};
+		let db = &mut db.with_conditions(conditions.into_iter().map(|l| l.0).collect());
 		match con {
 			ConstraintArg::BoolLin(lin) => {
 				let aggregated = BoolLinAggregator::default()
@@ -302,8 +304,13 @@ mod pindakaas {
 			Ok(())
 		}
 
-		fn add_encoding(&mut self, con: ConstraintArg, enc: Option<Encoder>) -> PyResult<()> {
-			encode_constraint(&mut self.0, con, enc)
+		fn add_encoding(
+			&mut self,
+			con: ConstraintArg,
+			enc: Option<Encoder>,
+			conditions: Vec<Lit>,
+		) -> PyResult<()> {
+			encode_constraint(&mut self.0, con, enc, conditions)
 		}
 
 		#[new]
@@ -491,8 +498,13 @@ mod pindakaas {
 			Ok(())
 		}
 
-		fn add_encoding(&mut self, con: ConstraintArg, enc: Option<Encoder>) -> PyResult<()> {
-			encode_constraint(&mut self.0, con, enc)
+		fn add_encoding(
+			&mut self,
+			con: ConstraintArg,
+			enc: Option<Encoder>,
+			conditions: Vec<Lit>,
+		) -> PyResult<()> {
+			encode_constraint(&mut self.0, con, enc, conditions)
 		}
 
 		fn add_weighted_clause(
@@ -598,9 +610,14 @@ mod pindakaas {
 				Ok(())
 			}
 
-			fn add_encoding(&mut self, con: ConstraintArg, enc: Option<Encoder>) -> PyResult<()> {
+			fn add_encoding(
+				&mut self,
+				con: ConstraintArg,
+				enc: Option<Encoder>,
+				conditions: Vec<Lit>,
+			) -> PyResult<()> {
 				let mut guard = self.0.lock().unwrap();
-				encode_constraint(&mut *guard, con, enc)
+				encode_constraint(&mut *guard, con, enc, conditions)
 			}
 
 			#[new]

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -132,14 +132,14 @@ mod pindakaas {
 		db: &mut Db,
 		con: ConstraintArg,
 		enc: Option<Encoder>,
-		conditions: Option<Vec<Lit>>,
+		conditions: Vec<Lit>,
 	) -> PyResult<()> {
-		if let Some(conditions) = conditions {
+		if !conditions.is_empty() {
 			return encode_constraint(
 				&mut db.with_conditions(conditions.into_iter().map(|l| l.0).collect()),
 				con,
 				enc,
-				None,
+				Vec::new(),
 			);
 		}
 		let invalid_enc = |con_ty, enc| {
@@ -315,7 +315,7 @@ mod pindakaas {
 			&mut self,
 			con: ConstraintArg,
 			enc: Option<Encoder>,
-			conditions: Option<Vec<Lit>>,
+			conditions: Vec<Lit>,
 		) -> PyResult<()> {
 			encode_constraint(&mut self.0, con, enc, conditions)
 		}
@@ -509,7 +509,7 @@ mod pindakaas {
 			&mut self,
 			con: ConstraintArg,
 			enc: Option<Encoder>,
-			conditions: Option<Vec<Lit>>,
+			conditions: Vec<Lit>,
 		) -> PyResult<()> {
 			encode_constraint(&mut self.0, con, enc, conditions)
 		}
@@ -621,7 +621,7 @@ mod pindakaas {
 				&mut self,
 				con: ConstraintArg,
 				enc: Option<Encoder>,
-				conditions: Option<Vec<Lit>>,
+				conditions: Vec<Lit>,
 			) -> PyResult<()> {
 				let mut guard = self.0.lock().unwrap();
 				encode_constraint(&mut *guard, con, enc, conditions)

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -132,8 +132,16 @@ mod pindakaas {
 		db: &mut Db,
 		con: ConstraintArg,
 		enc: Option<Encoder>,
-		conditions: Vec<Lit>,
+		conditions: Option<Vec<Lit>>,
 	) -> PyResult<()> {
+		if let Some(conditions) = conditions {
+			return encode_constraint(
+				&mut db.with_conditions(conditions.into_iter().map(|l| l.0).collect()),
+				con,
+				enc,
+				None,
+			);
+		}
 		let invalid_enc = |con_ty, enc| {
 			Err(InvalidEncoder::new_err(format!(
 				"unable to encode `{con_ty}' using {enc:?}"
@@ -142,7 +150,6 @@ mod pindakaas {
 		let map_unsat = |_err| {
 			Unsatisfiable::new_err("constraint was found to be unsatisfiable during encoding")
 		};
-		let db = &mut db.with_conditions(conditions.into_iter().map(|l| l.0).collect());
 		match con {
 			ConstraintArg::BoolLin(lin) => {
 				let aggregated = BoolLinAggregator::default()
@@ -308,7 +315,7 @@ mod pindakaas {
 			&mut self,
 			con: ConstraintArg,
 			enc: Option<Encoder>,
-			conditions: Vec<Lit>,
+			conditions: Option<Vec<Lit>>,
 		) -> PyResult<()> {
 			encode_constraint(&mut self.0, con, enc, conditions)
 		}
@@ -502,7 +509,7 @@ mod pindakaas {
 			&mut self,
 			con: ConstraintArg,
 			enc: Option<Encoder>,
-			conditions: Vec<Lit>,
+			conditions: Option<Vec<Lit>>,
 		) -> PyResult<()> {
 			encode_constraint(&mut self.0, con, enc, conditions)
 		}
@@ -614,7 +621,7 @@ mod pindakaas {
 				&mut self,
 				con: ConstraintArg,
 				enc: Option<Encoder>,
-				conditions: Vec<Lit>,
+				conditions: Option<Vec<Lit>>,
 			) -> PyResult<()> {
 				let mut guard = self.0.lock().unwrap();
 				encode_constraint(&mut *guard, con, enc, conditions)


### PR DESCRIPTION
 Add simple `conditions` argument to `add_encoding` to support implied bool linears. Still open for a better interface, however, this would mix the propositional and PB constraints in a non-trivial way.

Other question: the `conditions` imply to me they should be added as negative literals `((/\ conditions) -> clause) == \/ ~c for c in conditions \/ clause`, but they are added positively (in a sense, it's more that every clause is extended by some literals, rather than implied by them). Should we change this in `ConditionalDatabase`?