### PR TITLE
Prevent cargo_warnings error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ categories = ["algorithms", "mathematics", "science"]
 keywords = ["satisfiability", "encoding", "boolean", "logic", "cnf", "sat"]
 
 [workspace.dependencies]
-cc = { version = "1.0", features = ["parallel"] }
+cc = { version = "1.2", features = ["parallel"] }
 quote = "1.0"
 syn = { version = "2.0" }
 tracing = "0.1.40"

--- a/crates/pindakaas-intel-sat/build.rs
+++ b/crates/pindakaas-intel-sat/build.rs
@@ -51,5 +51,5 @@ fn main() {
 	let _ = build.define("NDEBUG", None);
 
 	change_ipasir_prefix(build, "intel_sat");
-	build.files(src).cargo_warnings(false).compile("intel_sat");
+	build.files(src).warnings(false).compile("intel_sat");
 }

--- a/crates/pindakaas-intel-sat/build.rs
+++ b/crates/pindakaas-intel-sat/build.rs
@@ -51,5 +51,5 @@ fn main() {
 	let _ = build.define("NDEBUG", None);
 
 	change_ipasir_prefix(build, "intel_sat");
-	build.files(src).warnings(false).compile("intel_sat");
+	build.files(src).cargo_warnings(false).compile("intel_sat");
 }


### PR DESCRIPTION
I get this error, so I followed the help, but I'm not sure if this changes the intended type of warning?

```rs
error[E0599]: no method named `cargo_warnings` found for mutable reference `&mut Build` in the current scope
  --> crates/pindakaas-intel-sat/build.rs:54:19
   |
54 |     build.files(src).cargo_warnings(false).compile("intel_sat");
   |                      ^^^^^^^^^^^^^^
   |
help: there is a method `warnings` with a similar name
   |
54 -     build.files(src).cargo_warnings(false).compile("intel_sat");
54 +     build.files(src).warnings(false).compile("intel_sat");
   |
```