### PR TITLE
Add documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ sdist/
 
 # Python Maturin (files created because it doesn't support workspaces)
 /crates/pyndakaas/target
+/crates/pyndakaas/docs/build
 /crates/pyndakaas/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/pindakaashq/pindakaas"
 version = "0.1.0"
 authors = [
 	"Jip J. Dekker <jip@dekker.one>",
-	"Hendrik 'Henk' Bierlee <hendrik.bierlee@monash.edu>",
+	"Hendrik 'Henk' Bierlee <henk.bierlee@kuleuven.be>",
 ]
 edition = "2021"
 license = "MPL-2.0"

--- a/crates/pindakaas/src/lib.rs
+++ b/crates/pindakaas/src/lib.rs
@@ -73,7 +73,7 @@ pub trait Checker {
 /// To satisfy the trait, the type must implement a [`Self::add_clause`] method
 /// and a [`Self::new_var`] method.
 pub trait ClauseDatabase {
-	/// Add a clause to the `ClauseDatabase`. The databae is allowed to return
+	/// Add a clause to the `ClauseDatabase`. The database is allowed to return
 	/// [`Unsatisfiable`] when the collection of clauses has been *proven* to be
 	/// unsatisfiable. This is used as a signal to the encoder that any subsequent
 	/// encoding effort can be abandoned.
@@ -84,7 +84,7 @@ pub trait ClauseDatabase {
 }
 
 pub trait ClauseDatabaseTools: ClauseDatabase {
-	/// Add a clause, given as any  to the `ClauseDatabase`. The databae is allowed to return
+	/// Add a clause, given as any to the `ClauseDatabase`. The database is allowed to return
 	/// [`Unsatisfiable`] when the collection of clauses has been *proven* to be
 	/// unsatisfiable. This is used as a signal to the encoder that any subsequent
 	/// encoding effort can be abandoned.

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -12,3 +12,6 @@ crate-type = ["cdylib"]
 itertools = "0.14.0"
 pindakaas = { path = "../pindakaas" }
 pyo3 = "0.24.0"
+
+[lints]
+workspace = true

--- a/crates/pyndakaas/docs/Makefile
+++ b/crates/pyndakaas/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 # TODO Added -E -a to force reload for autodoc, otherwise the re-generation of the build is very inconsistent!
-SPHINXOPTS    ?= -E -a 
+SPHINXOPTS    ?= -E -a
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
@@ -18,7 +18,7 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	pip install -e ..[docs]
+	pip install --group ../pyproject.toml:docs
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) -E -a $(O)
 
 # Live HTML view of the documentation for development (requires `sphinx-autobuild` to be installed). Recompiles the crate on every change.

--- a/crates/pyndakaas/docs/Makefile
+++ b/crates/pyndakaas/docs/Makefile
@@ -23,6 +23,6 @@ help:
 
 # Live HTML view of the documentation for development (requires `sphinx-autobuild` to be installed). Recompiles the crate on every change.
 livehtml:
-	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) --pre-build "pip install -e ..[docs]" --open-browser --watch ../src --watch ../python/pindakaas/solver.py --watch ../python/pindakaas/encoding.py $(O)
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) --pre-build "pip install -e ..[docs]" --watch ../src --watch ../python/pindakaas/solver.py --watch ../python/pindakaas/encoding.py $(O)
 	# TODO does not quite work
 	# sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) --pre-build "pip install -e ..[docs]" --open-browser --watch ../src --watch ../python/pindakaas/*.py $(O)

--- a/crates/pyndakaas/docs/Makefile
+++ b/crates/pyndakaas/docs/Makefile
@@ -3,7 +3,8 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+# TODO Added -E -a to force reload for autodoc, otherwise the re-generation of the build is very inconsistent!
+SPHINXOPTS    ?= -E -a 
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
@@ -17,8 +18,11 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	pip install -e ..[docs]
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) -E -a $(O)
 
 # Live HTML view of the documentation for development (requires `sphinx-autobuild` to be installed). Recompiles the crate on every change.
 livehtml:
-	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) --pre-build "pip install -e ..[docs]" --open-browser --watch ../src $(O)
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) --pre-build "pip install -e ..[docs]" --open-browser --watch ../src --watch ../python/pindakaas/solver.py --watch ../python/pindakaas/encoding.py $(O)
+	# TODO does not quite work
+	# sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) --pre-build "pip install -e ..[docs]" --open-browser --watch ../src --watch ../python/pindakaas/*.py $(O)

--- a/crates/pyndakaas/docs/Makefile
+++ b/crates/pyndakaas/docs/Makefile
@@ -1,0 +1,24 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# Live HTML view of the documentation for development (requires `sphinx-autobuild` to be installed). Recompiles the crate on every change.
+livehtml:
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) --pre-build "pip install -e ..[docs]" --open-browser --watch ../src $(O)

--- a/crates/pyndakaas/docs/make.bat
+++ b/crates/pyndakaas/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/crates/pyndakaas/docs/source/api.rst
+++ b/crates/pyndakaas/docs/source/api.rst
@@ -1,0 +1,14 @@
+API
+===
+
+The specification of the Pindakaas API
+
+.. automodule:: pindakaas
+   :members:
+   :undoc-members:
+
+.. automodule:: pindakaas.solver
+   :members:
+   :undoc-members:
+
+

--- a/crates/pyndakaas/docs/source/conf.py
+++ b/crates/pyndakaas/docs/source/conf.py
@@ -18,10 +18,12 @@ extensions = [
     'sphinx_rtd_theme',
 ]
 
+autodoc_typehints = "description"  # show type hints from signature in docs
+
 templates_path = ['_templates']
 exclude_patterns = []
 todo_include_todos = True
 
 html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
+# html_static_path = ['_static']
 

--- a/crates/pyndakaas/docs/source/conf.py
+++ b/crates/pyndakaas/docs/source/conf.py
@@ -1,0 +1,27 @@
+import tomllib
+with open("../../../../Cargo.toml", "rb") as f:
+    cargo = tomllib.load(f)
+    package = cargo["workspace"]["package"]
+    author = ", ".join(author.replace("<","(").replace(">",")")  for author in package["authors"])
+    release = package["version"]
+
+with open("../../../pindakaas/Cargo.toml", "rb") as f:
+    cargo = tomllib.load(f)
+    package = cargo["package"]
+    description = package["description"]
+    project = package["name"]
+    copyright = f"2024-2025, {author}"
+version = release
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx_rtd_theme',
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+todo_include_todos = True
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']
+

--- a/crates/pyndakaas/docs/source/conf.py
+++ b/crates/pyndakaas/docs/source/conf.py
@@ -1,8 +1,11 @@
 import tomllib
+
 with open("../../../../Cargo.toml", "rb") as f:
     cargo = tomllib.load(f)
     package = cargo["workspace"]["package"]
-    author = ", ".join(author.replace("<","(").replace(">",")")  for author in package["authors"])
+    author = ", ".join(
+        author.replace("<", "(").replace(">", ")") for author in package["authors"]
+    )
     release = package["version"]
 
 with open("../../../pindakaas/Cargo.toml", "rb") as f:
@@ -15,16 +18,16 @@ with open("../../../pindakaas/Cargo.toml", "rb") as f:
 version = release
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx_rtd_theme',
+    "sphinx.ext.autodoc",
+    "sphinx_rtd_theme",
 ]
 
 autodoc_typehints = "description"  # show type hints from signature in docs
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
 
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 # html_static_path = ['_static']
 
 html_logo = "../../../../assets/logo.svg"
@@ -33,4 +36,3 @@ pygments_style = "sphinx"
 # html_theme_options = {
 #     'logo_only': True,
 # }
-

--- a/crates/pyndakaas/docs/source/conf.py
+++ b/crates/pyndakaas/docs/source/conf.py
@@ -11,6 +11,7 @@ with open("../../../pindakaas/Cargo.toml", "rb") as f:
     description = package["description"]
     project = package["name"]
     copyright = f"2024-2025, {author}"
+
 version = release
 
 extensions = [
@@ -22,8 +23,14 @@ autodoc_typehints = "description"  # show type hints from signature in docs
 
 templates_path = ['_templates']
 exclude_patterns = []
-todo_include_todos = True
 
 html_theme = 'sphinx_rtd_theme'
 # html_static_path = ['_static']
+
+html_logo = "../../../../assets/logo.svg"
+pygments_style = "sphinx"
+
+# html_theme_options = {
+#     'logo_only': True,
+# }
 

--- a/crates/pyndakaas/docs/source/getting_started.rst
+++ b/crates/pyndakaas/docs/source/getting_started.rst
@@ -1,0 +1,30 @@
+Getting started
+===============
+
+This section describes how to get started with Pindakaas.
+
+Installation
+------------
+
+..  code-block:: bash
+
+    $ pip install pindakaas
+
+Basic example
+-------------
+
+.. literalinclude:: ../../examples/example.py
+   :language: python
+
+Further examples
+----------------
+
+Model and encode Boolean formulae and pseudo-Boolean constraints:
+
+.. literalinclude:: ../../examples/example_modelling.py
+   :language: python
+
+Solve incrementally using assumptions:
+
+.. literalinclude:: ../../examples/example_modelling.py
+   :language: python

--- a/crates/pyndakaas/docs/source/index.rst
+++ b/crates/pyndakaas/docs/source/index.rst
@@ -1,25 +1,17 @@
-..
-
 Pindakaas
-=========================================================================
+=========
 
 **Encoding propositional and Pseudo Boolean constraints into CNF**
 
 This documentation describes the Python interface to the Pindakaas Rust library.
 See the `Rust documentation <https://crates.io/crates/pindakaas>`_ for more in-depth information.
 
+.. The full API is described in the following section.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
 
-
-.. automodule:: pindakaas
-   :members:
-   :undoc-members:
-
-.. automodule:: pindakaas.solver
-   :members:
-   :undoc-members:
-
+   getting_started
+   api
+  
 

--- a/crates/pyndakaas/docs/source/index.rst
+++ b/crates/pyndakaas/docs/source/index.rst
@@ -1,10 +1,12 @@
 ..
 
-Pindakaas: Encoding propositional and Pseudo Boolean constraints into CNF 
+Pindakaas
 =========================================================================
 
+**Encoding propositional and Pseudo Boolean constraints into CNF**
+
 This documentation describes the Python interface to the Pindakaas Rust library.
-See the forthcoming `Rust documentation <https://crates.io/crates/pindakaas>`_ for more in-depth information.
+See the `Rust documentation <https://crates.io/crates/pindakaas>`_ for more in-depth information.
 
 
 .. toctree::

--- a/crates/pyndakaas/docs/source/index.rst
+++ b/crates/pyndakaas/docs/source/index.rst
@@ -1,10 +1,10 @@
-.. Pindakaas documentation master file, created by
-   sphinx-quickstart on Mon Mar 31 13:39:43 2025.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+..
 
-Pindakaas: Encoding Pseudo Boolean constraints into CNF 
-===================================================================
+Pindakaas: Encoding propositional and Pseudo Boolean constraints into CNF 
+=========================================================================
+
+This documentation describes the Python interface to the Pindakaas Rust library.
+See the forthcoming `Rust documentation <https://crates.io/crates/pindakaas>`_ for more in-depth information.
 
 
 .. toctree::
@@ -16,10 +16,8 @@ Pindakaas: Encoding Pseudo Boolean constraints into CNF
    :members:
    :undoc-members:
 
-
-Solvers
--------
-
-.. automodule:: pindakaas.solvers
+.. automodule:: pindakaas.solver
    :members:
    :undoc-members:
+
+

--- a/crates/pyndakaas/docs/source/index.rst
+++ b/crates/pyndakaas/docs/source/index.rst
@@ -1,0 +1,25 @@
+.. Pindakaas documentation master file, created by
+   sphinx-quickstart on Mon Mar 31 13:39:43 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Pindakaas: Encoding Pseudo Boolean constraints into CNF 
+===================================================================
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+.. automodule:: pindakaas
+   :members:
+   :undoc-members:
+
+
+Solvers
+-------
+
+.. automodule:: pindakaas.solvers
+   :members:
+   :undoc-members:

--- a/crates/pyndakaas/examples/example.py
+++ b/crates/pyndakaas/examples/example.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+import pindakaas
+
+# Instantiate solver, create two new literals, and encode a XOR constraint
+slv = pindakaas.solver.CaDiCaL()
+x, y, z = slv.new_vars(3)
+slv += x ^ y
+
+# Solve and inspect status and literal values
+with slv.solve() as result:
+    assert result.status == pindakaas.solver.Status.SATISFIED
+    assert result.value(x) != result.value(y)

--- a/crates/pyndakaas/examples/example_assumptions.py
+++ b/crates/pyndakaas/examples/example_assumptions.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+import pindakaas
+
+# Instantiate solver, create two new literals, and encode a XOR constraint
+slv = pindakaas.solver.CaDiCaL()
+x, y, z = slv.new_vars(3)
+slv += x ^ y
+
+with slv.solve(assumptions=[x]) as result:
+    assert result.value(x) is True
+    assert result.value(y) is False
+
+with slv.solve(assumptions=[x, y]) as result:
+    assert result.status == pindakaas.solver.Status.UNSATISFIABLE

--- a/crates/pyndakaas/examples/example_modelling.py
+++ b/crates/pyndakaas/examples/example_modelling.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+import pindakaas
+
+f = pindakaas.CNF()
+x, y, z = f.new_vars(3)
+f += (x & ~y) | (y == z)  # `x and not y, or y iff z`
+f += 2 * x + 3 * y + 5 * z <= 6
+print(f.to_dimacs())

--- a/crates/pyndakaas/pyproject.toml
+++ b/crates/pyndakaas/pyproject.toml
@@ -2,6 +2,15 @@
 requires = ["maturin>=1.8,<2.0"]
 build-backend = "maturin"
 
+[dependency-groups]
+dev = ["ruff>=0.12.0"]
+docs = [
+	"sphinx>=7.1.2",
+	"sphinx-autobuild>=2021.3.14",
+	"sphinx-rtd-theme>=3.0.2",
+]
+test = ["pytest>=8.3.5"]
+
 [project]
 name = "pindakaas"
 requires-python = ">=3.8"
@@ -11,9 +20,6 @@ classifiers = [
 	"Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
-[project.optional-dependencies]
-tests = ["pytest"]
-docs = ["sphinx", "sphinx_rtd_theme", "sphinx-autobuild"]
 
 [tool.maturin]
 python-source = "python"
@@ -21,3 +27,4 @@ features = ["pyo3/extension-module"]
 
 [tool.ruff]
 lint.select = ['B', 'C', 'E', 'I', 'F', 'W']
+lint.pycodestyle.max-doc-length = 88

--- a/crates/pyndakaas/pyproject.toml
+++ b/crates/pyndakaas/pyproject.toml
@@ -13,6 +13,10 @@ classifiers = [
 dynamic = ["version"]
 [project.optional-dependencies]
 tests = ["pytest"]
+docs = ["sphinx", "sphinx_rtd_theme", "sphinx-autobuild"]
+
+# [project.scripts]
+
 [tool.maturin]
 python-source = "python"
 features = ["pyo3/extension-module"]

--- a/crates/pyndakaas/pyproject.toml
+++ b/crates/pyndakaas/pyproject.toml
@@ -15,8 +15,6 @@ dynamic = ["version"]
 tests = ["pytest"]
 docs = ["sphinx", "sphinx_rtd_theme", "sphinx-autobuild"]
 
-# [project.scripts]
-
 [tool.maturin]
 python-source = "python"
 features = ["pyo3/extension-module"]

--- a/crates/pyndakaas/pyproject.toml
+++ b/crates/pyndakaas/pyproject.toml
@@ -20,3 +20,6 @@ docs = ["sphinx", "sphinx_rtd_theme", "sphinx-autobuild"]
 [tool.maturin]
 python-source = "python"
 features = ["pyo3/extension-module"]
+
+[tool.ruff]
+lint.select = ['B', 'C', 'E', 'I', 'F', 'W']

--- a/crates/pyndakaas/python/pindakaas/__init__.py
+++ b/crates/pyndakaas/python/pindakaas/__init__.py
@@ -1,7 +1,7 @@
 import pindakaas.solver
 
 from .encoding import CNF, WCNF, ClauseDatabase, Constraint
-from .pindakaas import Formula, Lit, Encoder, Unsatisfiable, InvalidEncoder
+from .pindakaas import Encoder, Formula, InvalidEncoder, Lit, Unsatisfiable
 
 __doc__ = pindakaas.__doc__
 __all__ = [

--- a/crates/pyndakaas/python/pindakaas/encoding.py
+++ b/crates/pyndakaas/python/pindakaas/encoding.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Iterable, Optional, TypeAlias
 
 # TODO [?] what should we call the inernal database? Database, encoding, formula.. I'm preferring database so it does not overlap with the other terms too much.
-from .pindakaas import CNFInner, Formula, Lit, WCNFInner, Encoder
+from .pindakaas import CNFInner, Encoder, Formula, Lit, WCNFInner
 
 Constraint: TypeAlias = Formula
 

--- a/crates/pyndakaas/python/pindakaas/encoding.py
+++ b/crates/pyndakaas/python/pindakaas/encoding.py
@@ -7,7 +7,9 @@ Constraint: TypeAlias = Formula
 
 
 class ClauseDatabase(ABC):
-    """The abstract class to represent objects (e.g. CNF, SAT solver) to which we can add clauses."""
+    """The abstract class to represent objects (e.g. CNF, SAT solver) to which we can
+    add clauses.
+    """
 
     def __iadd__(self, constraint: Constraint):
         self.add_encoding(constraint)
@@ -29,7 +31,9 @@ class ClauseDatabase(ABC):
         encoder: Optional[Encoder] = None,
         conditions: Optional[Iterable[Lit]] = None,
     ):
-        """Add an encoding of a `constraint` to the database. Optionally, the constraint is implied by the given `conditions` (i.e. every clause is extended by the `conditions`), and the given `encoder` is used for the encoding.
+        """Add an encoding of a `constraint` to the database. Optionally, the constraint
+        is implied by the given `conditions` (i.e. every clause is extended by the
+        `conditions`), and the given `encoder` is used for the encoding.
 
         :param constraint: The constraint or formula to encode and add to the database
         :raises Unsatisfiable: If the formula has become unsatisfiable
@@ -82,7 +86,9 @@ class CNF(ClauseDatabase):
 
 
 class WCNF(CNF):
-    """A representation for Boolean formulas in conjunctive normal form with weighted (soft) clauses."""
+    """A representation for Boolean formulas in conjunctive normal form with weighted
+    (soft) clauses.
+    """
 
     _inner: WCNFInner
 

--- a/crates/pyndakaas/python/pindakaas/encoding.py
+++ b/crates/pyndakaas/python/pindakaas/encoding.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Iterable, Optional, TypeAlias
 
-# TODO [?] what should we call the inernal database? Database, encoding, formula.. I'm preferring database so it does not overlap with the other terms too much.
 from .pindakaas import CNFInner, Encoder, Formula, Lit, WCNFInner
 
 Constraint: TypeAlias = Formula
@@ -10,7 +9,7 @@ RAISES_UNSAT = ":raises Unsatisfiable: If the formula has become unsatisfiable"
 
 
 class ClauseDatabase(ABC):
-    """The abstract class representing an object to which we can add clauses, such as a CNF or solver."""
+    """The abstract class to represent objects (e.g. CNF, SAT solver)to which we can add clauses."""
 
     def __iadd__(self, constraint: Constraint):
         self.add_encoding(constraint)

--- a/crates/pyndakaas/python/pindakaas/encoding.py
+++ b/crates/pyndakaas/python/pindakaas/encoding.py
@@ -5,11 +5,9 @@ from .pindakaas import CNFInner, Encoder, Formula, Lit, WCNFInner
 
 Constraint: TypeAlias = Formula
 
-RAISES_UNSAT = ":raises Unsatisfiable: If the formula has become unsatisfiable"
-
 
 class ClauseDatabase(ABC):
-    """The abstract class to represent objects (e.g. CNF, SAT solver)to which we can add clauses."""
+    """The abstract class to represent objects (e.g. CNF, SAT solver) to which we can add clauses."""
 
     def __iadd__(self, constraint: Constraint):
         self.add_encoding(constraint)
@@ -20,10 +18,9 @@ class ClauseDatabase(ABC):
         """Add a clause to the database.
 
         :param clause: An iterable of literals representing the clause to add
+        :raises Unsatisfiable: If the formula has become unsatisfiable
         """
         ...
-
-    add_clause.__doc__ += RAISES_UNSAT
 
     @abstractmethod
     def add_encoding(
@@ -35,10 +32,9 @@ class ClauseDatabase(ABC):
         """Add an encoding of a `constraint` to the database. Optionally, the constraint is implied by the given `conditions` (i.e. every clause is extended by the `conditions`), and the given `encoder` is used for the encoding.
 
         :param constraint: The constraint or formula to encode and add to the database
+        :raises Unsatisfiable: If the formula has become unsatisfiable
         """
         ...
-
-    add_encoding.__doc__ += RAISES_UNSAT
 
     def new_var(self):
         """Add a new variable to the database."""

--- a/crates/pyndakaas/python/pindakaas/encoding.py
+++ b/crates/pyndakaas/python/pindakaas/encoding.py
@@ -1,18 +1,30 @@
 from abc import ABC, abstractmethod
 from typing import Iterable, Optional, TypeAlias
 
+# TODO [?] what should we call the inernal database? Database, encoding, formula.. I'm preferring database so it does not overlap with the other terms too much.
 from .pindakaas import CNFInner, Formula, Lit, WCNFInner, Encoder
 
 Constraint: TypeAlias = Formula
 
+RAISES_UNSAT = ":raises Unsatisfiable: If the formula has become unsatisfiable"
+
 
 class ClauseDatabase(ABC):
+    """The abstract class representing an object to which we can add clauses, such as a CNF or solver."""
+
     def __iadd__(self, constraint: Constraint):
         self.add_encoding(constraint)
         return self
 
     @abstractmethod
-    def add_clause(self, clause: Iterable[Lit]): ...
+    def add_clause(self, clause: Iterable[Lit]):
+        """Add a clause to the database.
+
+        :param clause: An iterable of literals representing the clause to add
+        """
+        ...
+
+    add_clause.__doc__ += RAISES_UNSAT
 
     @abstractmethod
     def add_encoding(
@@ -20,16 +32,32 @@ class ClauseDatabase(ABC):
         constraint: Constraint,
         encoder: Optional[Encoder] = None,
         conditions: Optional[Iterable[Lit]] = None,
-    ): ...
+    ):
+        """Add an encoding of a `constraint` to the database. Optionally, the constraint is implied by the given `conditions` (i.e. every clause is extended by the `conditions`), and the given `encoder` is used for the encoding.
+
+        :param constraint: The constraint or formula to encode and add to the database
+        """
+        ...
+
+    add_encoding.__doc__ += RAISES_UNSAT
 
     def new_var(self):
+        """Add a new variable to the database."""
         return self.new_vars(1).__iter__().__next__()
 
     @abstractmethod
-    def new_vars(self, num: int) -> Iterable[Lit]: ...
+    def new_vars(self, n: int) -> Iterable[Lit]:
+        """Add `n` new variables to the database.
+
+        :param n: The number of new variables
+        :return: The new variables returned as literals
+        """
+        ...
 
 
 class CNF(ClauseDatabase):
+    """A representation for Boolean formulas in conjunctive normal form."""
+
     _inner: CNFInner
 
     def __init__(self):
@@ -47,18 +75,29 @@ class CNF(ClauseDatabase):
         conditions = list(conditions) if conditions is not None else []
         return self._inner.add_encoding(constraint, encoder, conditions)
 
-    def new_vars(self, num: int) -> Iterable[Lit]:
-        return self._inner.new_vars(num)
+    def new_vars(self, n: int) -> Iterable[Lit]:
+        return self._inner.new_vars(n)
 
     def to_dimacs(self) -> str:
+        """Return a textual representation in the DIMACS format.
+
+        :return: The CNF as a DIMACS string
+        """
         return self._inner.to_dimacs()
 
 
 class WCNF(CNF):
+    """A representation for Boolean formulas in conjunctive normal form with weighted (soft) clauses."""
+
     _inner: WCNFInner
 
     def __init__(self):
         self._inner = WCNFInner()
 
     def add_weighted_clause(self, clause: Iterable[Lit], weight: int):
+        """Add a weighted clause to the database.
+
+        :param clause: An iterable of literals representing the clause to add
+        :param weight: the weight of the clause
+        """
         return self._inner.add_weighted_clause(iter(clause), weight)

--- a/crates/pyndakaas/python/pindakaas/solver.py
+++ b/crates/pyndakaas/python/pindakaas/solver.py
@@ -11,7 +11,7 @@ from .pindakaas.solver import CaDiCaLInner, Status
 
 
 class Result(ABC):
-    """The Result object returned from solving, allowing access to e.g. solver status and the values of variables."""
+    """The Result object returned after calling `solve()`. It allows access to e.g. solver status and the values of variables."""
 
     @property
     @abstractmethod

--- a/crates/pyndakaas/python/pindakaas/solver.py
+++ b/crates/pyndakaas/python/pindakaas/solver.py
@@ -11,7 +11,9 @@ from .pindakaas.solver import CaDiCaLInner, Status
 
 
 class Result(ABC):
-    """The Result object returned after calling `solve()`. It allows access to e.g. solver status and the values of variables."""
+    """The Result object returned after calling `solve()`. It allows access to e.g.
+    solver status and the values of variables.
+    """
 
     @property
     @abstractmethod
@@ -30,9 +32,13 @@ class Result(ABC):
 
     @abstractmethod
     def failed(self, lit: Lit) -> Optional[bool]:
-        """Check if the given assumption literal was used to prove the unsatisfiability of the formula under the assumptions used for the last SAT search. Note that for literals `lit` which are not assumption literals, the behavior of is not specified.
+        """Check if the given assumption literal was used to prove the unsatisfiability
+        of the formula under the assumptions used for the last SAT search. Note that for
+        literals `lit` which are not assumption literals, the behavior of is not
+        specified.
 
-        :param lit: the assumption literal for which to return whether it contributed to the unsatisfiable result
+        :param lit: the assumption literal for which to return whether it contributed to
+        the unsatisfiable result
         :return: whether `lit` contributed to the unsatisfiable result
         """
         ...
@@ -56,8 +62,10 @@ class Solver(ClauseDatabase):
     ) -> Iterator[Result]:
         """Solve the current `ClauseDatabase`.
 
-        :param assumptions: an optional iterable of assumptions literals which must hold for this solve call
-        :param time_limit: an optional time limit before which the solver is terminated and the result is Unknown
+        :param assumptions: an optional iterable of assumptions literals which must hold
+        for this solve call
+        :param time_limit: an optional time limit before which the solver is terminated
+        and the result is Unknown
         """
         self._set_time_limit(time_limit)
         assumptions = assumptions if assumptions is not None else []
@@ -98,8 +106,8 @@ class CaDiCaL(Solver):
         conditions = list(conditions) if conditions is not None else []
         return self._inner.add_encoding(constraint, encoder, conditions)
 
-    def new_vars(self, num: int):
-        return self._inner.new_vars(num)
+    def new_vars(self, n: int):
+        return self._inner.new_vars(n)
 
 
 class MapResult(Result):

--- a/crates/pyndakaas/python/pindakaas/solver.py
+++ b/crates/pyndakaas/python/pindakaas/solver.py
@@ -2,12 +2,12 @@
 
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import ContextManager, Iterable, Iterator, Optional
 from datetime import timedelta
+from typing import ContextManager, Iterable, Iterator, Optional
 
 from .encoding import ClauseDatabase, Constraint
-from .pindakaas import Lit, Encoder
-from .pindakaas.solver import Status, CaDiCaLInner
+from .pindakaas import Encoder, Lit
+from .pindakaas.solver import CaDiCaLInner, Status
 
 
 class Result(ABC):

--- a/crates/pyndakaas/python/pindakaas/solver.py
+++ b/crates/pyndakaas/python/pindakaas/solver.py
@@ -1,3 +1,5 @@
+"""A module containing solvers and solving related classes."""
+
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import ContextManager, Iterable, Iterator, Optional
@@ -9,18 +11,36 @@ from .pindakaas.solver import Status, CaDiCaLInner
 
 
 class Result(ABC):
+    """The Result object returned from solving, allowing access to e.g. solver status and the values of variables."""
+
     @property
     @abstractmethod
-    def status(self) -> Status: ...
+    def status(self) -> Status:
+        """Return result from solving the database."""
+        ...
 
     @abstractmethod
-    def value(self, var: Lit) -> Optional[bool]: ...
+    def value(self, lit: Lit) -> Optional[bool]:
+        """Return value for literal `lit`, or `None` if `lit` is assigned.
+
+        :param lit: the literal for which to return the value
+        :return: the value of `lit` if assigned
+        """
+        ...
 
     @abstractmethod
-    def failed(self, var: Lit) -> Optional[bool]: ...
+    def failed(self, lit: Lit) -> Optional[bool]:
+        """Check if the given assumption literal was used to prove the unsatisfiability of the formula under the assumptions used for the last SAT search. Note that for literals `lit` which are not assumption literals, the behavior of is not specified.
+
+        :param lit: the assumption literal for which to return whether it contributed to the unsatisfiable result
+        :return: whether `lit` contributed to the unsatisfiable result
+        """
+        ...
 
 
 class Solver(ClauseDatabase):
+    """An abstract class which extends a `ClauseDatabase` with solving capabilities."""
+
     def _set_time_limit(self, limit: Optional[timedelta]):
         if limit is not None:
             raise NotImplementedError("Solver does not support setting a time limit")
@@ -34,6 +54,11 @@ class Solver(ClauseDatabase):
         assumptions: Optional[Iterable[Lit]] = None,
         time_limit: Optional[timedelta] = None,
     ) -> Iterator[Result]:
+        """Solve the current `ClauseDatabase`.
+
+        :param assumptions: an optional iterable of assumptions literals which must hold for this solve call
+        :param time_limit: an optional time limit before which the solver is terminated and the result is Unknown
+        """
         self._set_time_limit(time_limit)
         assumptions = assumptions if assumptions is not None else []
         try:
@@ -44,9 +69,12 @@ class Solver(ClauseDatabase):
 
 
 class CaDiCaL(Solver):
+    """The `CaDiCaL <https://github.com/arminbiere/cadical>`_ SAT solver."""
+
     _inner: CaDiCaLInner
 
     def __init__(self):
+        """Initialize solver."""
         self._inner = CaDiCaLInner()
 
     def _set_time_limit(self, limit: Optional[timedelta]):
@@ -83,12 +111,12 @@ class MapResult(Result):
     def status(self) -> Status:
         return self._status
 
-    def value(self, var: Lit) -> Optional[bool]:
+    def value(self, lit: Lit) -> Optional[bool]:
         if self.status == Status.SATISFIED:
-            return self._mapping.get(int(var))
+            return self._mapping.get(int(lit))
         return None
 
-    def failed(self, var: Lit) -> Optional[bool]:
+    def failed(self, lit: Lit) -> Optional[bool]:
         if self.status == Status.UNSATISFIABLE:
-            return self._mapping.get(int(var)) == 0
+            return self._mapping.get(int(lit)) == 0
         return None

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -7,8 +7,13 @@ use std::sync::PoisonError;
 
 use pyo3::{create_exception, exceptions::PyException, prelude::*};
 
-create_exception!(pindakaas, InvalidEncoder, PyException);
-create_exception!(pindakaas, Unsatisfiable, PyException);
+create_exception!(pindakaas, InvalidEncoder, PyException, "Raised when the chosen encoder does not support the constraint (e.g. the [`PairwiseEncoder`] encoder for AMO constraints on a PB constraint).");
+create_exception!(
+	pindakaas,
+	Unsatisfiable,
+	PyException,
+	"Raised when the given constraint is found to be Unsatisfiable during encoding."
+);
 
 // Use Result i/o PyResult to use `?` to easily return Rust errors as Python exceptions
 type Result<R = (), E = ErrWrapper> = std::result::Result<R, E>;
@@ -343,6 +348,7 @@ mod pindakaas {
 
 	#[pymethods]
 	impl CNFInner {
+		/// hello everyone asdfldsaf
 		fn add_clause(&mut self, clause: Bound<'_, PyIterator>) -> Result {
 			let clause: Vec<Lit> = clause
 				.into_iter()

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -556,12 +556,12 @@ mod pindakaas {
 		}
 
 		/// Return whether the variable is negated
-		pub fn is_negated(&self) -> bool {
+		fn is_negated(&self) -> bool {
 			self.0.is_negated()
 		}
 
 		/// Return the literal's variable
-		pub fn var(&self) -> Self {
+		fn var(&self) -> Self {
 			Self(self.0.var().into())
 		}
 	}
@@ -643,7 +643,7 @@ mod pindakaas {
 
 		#[pyclass]
 		#[derive(Debug, Default)]
-		/// :meta private:
+		/// The internal representation of a instance of the CaDiCaL solver.
 		struct CaDiCaLInner(Mutex<Cadical>);
 
 		#[pyclass(eq, eq_int)]

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::PoisonError;
 
 use pyo3::{create_exception, exceptions::PyException, prelude::*};
 
-create_exception!(pindakaas, InvalidEncoder, PyException, "Raised when the chosen encoder does not support the constraint (e.g. the [`PairwiseEncoder`] encoder for AMO constraints on a PB constraint).");
+create_exception!(pindakaas, InvalidEncoder, PyException, "Raised when the chosen encoder does not support the constraint (e.g. when the `PairwiseEncoder` encoder for AMO constraints is used to encode a PB constraint).");
 create_exception!(
 	pindakaas,
 	Unsatisfiable,
@@ -74,6 +74,8 @@ mod pindakaas {
 	use crate::Unsatisfiable;
 
 	#[derive(FromPyObject)]
+	// TODO [?] Should the rust doc links be substituted for RST links with
+	// :class:`BoolLinExp`
 	/// Argument capture for types that can become [`BoolLinExp`].
 	enum BoolLinArg {
 		Bool(bool),
@@ -113,11 +115,11 @@ mod pindakaas {
 	#[expect(non_camel_case_types, reason = "match python naming convention")]
 	#[pyclass(eq, eq_int)]
 	#[derive(Clone, Copy, Debug, PartialEq)]
-	/// Method used to encode a constraint
+	/// Method used to encode a constraint.
 	///
-	/// Warning: Not all encoders can be used to encode each [`ConstraintArg`]. If an
-	/// invalid encoder is selected, then an exception will be raised.
+	/// Warning: Not all encoders can be used to encode each type of constraint. If an invalid encoder is selected, then an :class:`InvalidEncoder` exception will be raised.
 	enum Encoder {
+		// TODO [?] How to make this show up?
 		/// Use [`pindakaas::bool_linear::AdderEncoder`], which is able to encode
 		/// all Boolean linear constraints.
 		ADDER,
@@ -348,7 +350,6 @@ mod pindakaas {
 
 	#[pymethods]
 	impl CNFInner {
-		/// hello everyone asdfldsaf
 		fn add_clause(&mut self, clause: Bound<'_, PyIterator>) -> Result {
 			let clause: Vec<Lit> = clause
 				.into_iter()
@@ -556,10 +557,12 @@ mod pindakaas {
 			self.__xor__(other)
 		}
 
+		/// Return whether the variable is negated
 		pub fn is_negated(&self) -> bool {
 			self.0.is_negated()
 		}
 
+		/// Return the literal's variable
 		pub fn var(&self) -> Self {
 			Self(self.0.var().into())
 		}
@@ -642,6 +645,7 @@ mod pindakaas {
 
 		#[pyclass]
 		#[derive(Debug, Default)]
+		/// :meta private:
 		struct CaDiCaLInner(Mutex<Cadical>);
 
 		#[pyclass(eq, eq_int)]

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -74,9 +74,7 @@ mod pindakaas {
 	use crate::Unsatisfiable;
 
 	#[derive(FromPyObject)]
-	// TODO [?] Should the rust doc links be substituted for RST links with
-	// :class:`BoolLinExp`
-	/// Argument capture for types that can become [`BoolLinExp`].
+	/// Argument capture for types that can become :class:`BoolLinExp`.
 	enum BoolLinArg {
 		Bool(bool),
 		BoolLin(BoolLinExp),
@@ -94,7 +92,7 @@ mod pindakaas {
 	/// A Boolean linear expression, also known as a pseudo-Boolean expression.
 	///
 	/// Using operators `<`, `<=`, `==`, `>=`, and `>` with a `int` right hand
-	/// side, the expression can be turned into a [`BoolLinCon`].
+	/// side, the expression can be turned into a :class:`BoolLinCon`.
 	struct BoolLinExp(BaseBoolLinExp);
 
 	#[pyclass]
@@ -119,32 +117,32 @@ mod pindakaas {
 	///
 	/// Warning: Not all encoders can be used to encode each type of constraint. If an invalid encoder is selected, then an :class:`InvalidEncoder` exception will be raised.
 	enum Encoder {
-		// TODO [?] How to make this show up?
-		/// Use [`pindakaas::bool_linear::AdderEncoder`], which is able to encode
+		// TODO These doc-strings do not show up, upstream issue: https://github.com/PyO3/pyo3/issues/5197
+		/// Use :class:`pindakaas::bool_linear::AdderEncoder`, which is able to encode
 		/// all Boolean linear constraints.
 		ADDER,
-		/// Use [`pindakaas::cardinality_one::BitwiseEncoder`], which is able to
+		/// Use :class:`pindakaas::cardinality_one::BitwiseEncoder`, which is able to
 		/// encode all Boolean cardinality one constraints.
 		BITWISE,
-		/// Use [`pindakaas::bool_linear::BddEncoder`], which is able to encode
+		/// Use :class:`pindakaas::bool_linear::BddEncoder`, which is able to encode
 		/// all Boolean linear constraints.
 		DECISION_DIAGRAM,
-		/// Use [`pindakaas::cardinality_one::LadderEncoder`], which is able to
+		/// Use :class:`pindakaas::cardinality_one::LadderEncoder`, which is able to
 		/// encode all Boolean cardinality one constraints.
 		LADDER,
-		/// Use [`pindakaas::cardinality_one::PairwiseEncoder`], which is able to
+		/// Use :class:`pindakaas::cardinality_one::PairwiseEncoder`, which is able to
 		/// encode all Boolean cardinality one constraints.
 		PAIRWISE,
-		/// Use [`pindakaas::bool_linear::SwcEncoder`], which is able to encode all
+		/// Use :class:`pindakaas::bool_linear::SwcEncoder`, which is able to encode all
 		/// Boolean linear constraints.
 		SORTED_WEIGHT_COUNTER,
-		/// Use [`pindakaas::cardinality::SwcEncoder`], which is able to encode all
+		/// Use :class:`pindakaas::cardinality::SwcEncoder`, which is able to encode all
 		/// Boolean cardinality constraints.
 		SORTING_NETWORK,
-		/// Use [`pindakaas::bool_linear::TotalizerEncoder`], which is able to
+		/// Use :class:`pindakaas::bool_linear::TotalizerEncoder`, which is able to
 		/// encode all Boolean linear constraints.
 		TOTALIZER,
-		/// Use [`pindakaas::propositional_logic::TseitinEncdoer`], which is able to
+		/// Use :class:`pindakaas::propositional_logic::TseitinEncdoer`, which is able to
 		/// encode propositional logic formulas.
 		TSEITIN,
 	}
@@ -155,7 +153,7 @@ mod pindakaas {
 	struct Formula(BaseFormula<BoolVal>);
 
 	#[derive(FromPyObject)]
-	/// Argument capture for types that can become [`Formula`].
+	/// Argument capture for types that can become :class:`Formula`.
 	enum FormulaArg {
 		Const(bool),
 		Formula(Formula),
@@ -452,8 +450,8 @@ mod pindakaas {
 	}
 
 	impl FormulaArg {
-		/// Internal method used to convert the [`FormulaArg`] into a
-		/// [`BaseFormula<BoolVal>`].
+		/// Internal method used to convert the :class:`FormulaArg` into a
+		/// :class:`BaseFormula<BoolVal>`.
 		fn as_formula(&self) -> BaseFormula<BoolVal> {
 			use BaseFormula::*;
 


### PR DESCRIPTION
 First stab at Python-API docs.

Definitely it would be nice if the Rust doc-strings could be shared somehow, but I don't see a convenient way for this.

I've managed to get some "live-reloading" working. In general, the `apidoc` extension is very finicky, so we require extra CLI flags to ensure the documentation is regenerated after re-building/re-installing the Python package.

Definitely let me know what is missing to get things to a reasonable standard. There are some questions in the code marked by `TODO [?]`. Also, do we want to add the hosting already on this PR?

Another thing that popped in my head, should I add building docs to the CI?