### PR TITLE
fix: change licenses of solver crates to match underlying solvers

### DIFF
--- a/crates/pindakaas-cadical/Cargo.toml
+++ b/crates/pindakaas-cadical/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pindakaas-cadical"
 description = "build of the Cadical SAT solver for the pindakaas crate"
 version = "0.0.1"
+license = "MIT"
 
 include = [
 	"build.rs",
@@ -16,7 +17,6 @@ links = "cadical"
 
 authors.workspace = true
 edition.workspace = true
-license.workspace = true
 homepage.workspace = true
 categories.workspace = true
 keywords.workspace = true

--- a/crates/pindakaas-intel-sat/Cargo.toml
+++ b/crates/pindakaas-intel-sat/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pindakaas-intel-sat"
 description = "build of the Intel SAT solver for the pindakaas crate"
 version = "0.0.1"
+license = "MIT"
 
 build = "build.rs"
 links = "intel_sat"
@@ -14,7 +15,6 @@ include = [
 
 authors.workspace = true
 edition.workspace = true
-license.workspace = true
 homepage.workspace = true
 categories.workspace = true
 keywords.workspace = true

--- a/crates/pindakaas-kissat/Cargo.toml
+++ b/crates/pindakaas-kissat/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pindakaas-kissat"
 description = "build of the Kissat SAT solver for the pindakaas crate"
 version = "0.0.1"
+license = "MIT"
 
 build = "build.rs"
 links = "kissat"
@@ -15,7 +16,6 @@ include = [
 
 authors.workspace = true
 edition.workspace = true
-license.workspace = true
 homepage.workspace = true
 categories.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
This resolves #114