### PR TITLE
chore: release v0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2021"
 license = "MPL-2.0"
 homepage = "https://github.com/pindakaashq/pindakaas"
 categories = ["algorithms", "mathematics", "science"]
-keywords = ["satisfiability", "encoding", "boolean", "logic", "cnf", "sat"]
+keywords = ["satisfiability", "encoding", "boolean", "logic", "sat"]
 
 [workspace.dependencies]
 cc = { version = "1.2", features = ["parallel"] }

--- a/crates/pindakaas-cadical/CHANGELOG.md
+++ b/crates/pindakaas-cadical/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-cadical-v0.1.0) - 2025-07-09
+
+### Added
+
+- Initial release of the `pindakaas-cadical` crate, which provides Rust bindings
+  to the [CaDiCaL](https://github.com/arminbiere/cadical) SAT solver for
+  `pindakaas`.

--- a/crates/pindakaas-cadical/Cargo.toml
+++ b/crates/pindakaas-cadical/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-cadical"
 description = "build of the Cadical SAT solver for the pindakaas crate"
-version = "0.0.1"
+version = "0.1.0"
 license = "MIT"
 
 include = [

--- a/crates/pindakaas-derive/CHANGELOG.md
+++ b/crates/pindakaas-derive/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-derive-v0.1.0) - 2025-07-09
+
+### Added
+
+- Initial release of the `pindakaas-derive` crate, which provides internal
+  derive macros for the `pindakaas` crate to implement common Traits for SAT
+  solvers.

--- a/crates/pindakaas-derive/Cargo.toml
+++ b/crates/pindakaas-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-derive"
 description = "derive macros for the pindakaas crate to connect to SAT solvers"
-version = "0.0.1"
+version = "0.1.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/pindakaas-intel-sat/CHANGELOG.md
+++ b/crates/pindakaas-intel-sat/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-intel-sat-v0.1.0) - 2025-07-09
+
+### Added
+
+- Initial release of the `pindakaas-intel-sat` crate, which provides Rust bindings
+  to the [Intel SAT](https://github.com/alexander-nadel/intel_sat_solver) solver
+  for `pindakaas`.

--- a/crates/pindakaas-intel-sat/Cargo.toml
+++ b/crates/pindakaas-intel-sat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-intel-sat"
 description = "build of the Intel SAT solver for the pindakaas crate"
-version = "0.0.1"
+version = "0.1.0"
 license = "MIT"
 
 build = "build.rs"

--- a/crates/pindakaas-kissat/CHANGELOG.md
+++ b/crates/pindakaas-kissat/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-kissat-v0.1.0) - 2025-07-09
+
+### Added
+
+- Initial release of the `pindakaas-kissat` crate, which provides Rust bindings
+  to the [Kissat](https://github.com/arminbiere/kissat) SAT solver
+  for `pindakaas`.

--- a/crates/pindakaas-kissat/Cargo.toml
+++ b/crates/pindakaas-kissat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-kissat"
 description = "build of the Kissat SAT solver for the pindakaas crate"
-version = "0.0.1"
+version = "0.1.0"
 license = "MIT"
 
 build = "build.rs"

--- a/crates/pindakaas/CHANGELOG.md
+++ b/crates/pindakaas/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-cadical-v0.1.0) - 2025-07-09
+
+### Added
+
+- Initial release of the `pindakaas` crate, which helps encode pseudo-Boolean
+  constraints into CNF and interact with SAT solvers.

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas"
 description = "Encoding Integer and Pseudo Boolean constraints into CNF"
-version = "0.0.1"
+version = "0.1.0"
 
 authors.workspace = true
 edition.workspace = true
@@ -22,10 +22,10 @@ libloading = { version = "0.8", optional = true }
 tracing = { workspace = true, optional = true }
 
 # Optional Solver Interfaces
-pindakaas-cadical = { version = "0.0.1", path = "../pindakaas-cadical", optional = true }
-pindakaas-derive = { version = "0.0.1", path = "../pindakaas-derive", optional = true }
-pindakaas-intel-sat = { version = "0.0.1", path = "../pindakaas-intel-sat", optional = true }
-pindakaas-kissat = { version = "0.0.1", path = "../pindakaas-kissat", optional = true }
+pindakaas-cadical = { version = "0.1.0", path = "../pindakaas-cadical", optional = true }
+pindakaas-derive = { version = "0.1.0", path = "../pindakaas-derive", optional = true }
+pindakaas-intel-sat = { version = "0.1.0", path = "../pindakaas-intel-sat", optional = true }
+pindakaas-kissat = { version = "0.1.0", path = "../pindakaas-kissat", optional = true }
 splr = { version = "0.17", optional = true }
 
 [dev-dependencies]

--- a/crates/pyndakaas/CHANGELOG.md
+++ b/crates/pyndakaas/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pyndakaas-v0.1.0) - 2025-07-08
+
+### Added
+
+- Initial release of the `pyndakaas` crate, which provides Python bindings
+  for the `pindakaas` crate.

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.14.0"
-pindakaas = { version = "0.0.1", path = "../pindakaas" }
+pindakaas = { version = "0.1.0", path = "../pindakaas" }
 pyo3 = "0.24.0"
 
 [lints]


### PR DESCRIPTION



## 🤖 New release

* `pindakaas-cadical`: 0.1.0
* `pindakaas-derive`: 0.1.0
* `pindakaas-intel-sat`: 0.1.0
* `pindakaas-kissat`: 0.1.0
* `pyndakaas`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `pindakaas-cadical`

<blockquote>

## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-cadical-v0.1.0) - 2025-07-09

### Added

- Initial release of the `pindakaas-cadical` crate, which provides Rust bindings
  to the [CaDiCaL](https://github.com/arminbiere/cadical) SAT solver for
  `pindakaas`.
</blockquote>

## `pindakaas-derive`

<blockquote>

## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-derive-v0.1.0) - 2025-07-09

### Added

- Initial release of the `pindakaas-derive` crate, which provides internal
  derive macros for the `pindakaas` crate to implement common Traits for SAT
  solvers.
</blockquote>

## `pindakaas-intel-sat`

<blockquote>

## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-intel-sat-v0.1.0) - 2025-07-09

### Added

- Initial release of the `pindakaas-intel-sat` crate, which provides Rust bindings
  to the [Intel SAT](https://github.com/alexander-nadel/intel_sat_solver) solver
  for `pindakaas`.
</blockquote>

## `pindakaas-kissat`

<blockquote>

## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-kissat-v0.1.0) - 2025-07-09

### Added

- Initial release of the `pindakaas-kissat` crate, which provides Rust bindings
  to the [Kissat](https://github.com/arminbiere/kissat) SAT solver
  for `pindakaas`.
</blockquote>

## `pyndakaas`

<blockquote>

## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pyndakaas-v0.1.0) - 2025-07-08

### Added

- Initial release of the `pyndakaas` crate, which provides Python bindings
  for the `pindakaas` crate.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).