### PR TITLE
chore: release v0.1.1

### DIFF
--- a/crates/pindakaas-derive/CHANGELOG.md
+++ b/crates/pindakaas-derive/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-derive-v0.1.0...pindakaas-derive-v0.1.1) - 2025-07-24
+
+### Other
+
+- *(pindakaas-derive)* update darling requirement from 0.20 to 0.21 ([#128](https://github.com/pindakaashq/pindakaas/pull/128))
+
 ## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-derive-v0.1.0) - 2025-07-09
 
 ### Added

--- a/crates/pindakaas-derive/Cargo.toml
+++ b/crates/pindakaas-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-derive"
 description = "derive macros for the pindakaas crate to connect to SAT solvers"
-version = "0.1.0"
+version = "0.1.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/pindakaas/CHANGELOG.md
+++ b/crates/pindakaas/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.1.0...pindakaas-v0.1.1) - 2025-07-24
+
+### Other
+
+- updated the following local packages: pindakaas-derive
+
 ## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-cadical-v0.1.0) - 2025-07-09
 
 ### Added

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas"
 description = "Encoding Integer and Pseudo Boolean constraints into CNF"
-version = "0.1.0"
+version = "0.1.1"
 
 authors.workspace = true
 edition.workspace = true
@@ -23,7 +23,7 @@ tracing = { workspace = true, optional = true }
 
 # Optional Solver Interfaces
 pindakaas-cadical = { version = "0.1.0", path = "../pindakaas-cadical", optional = true }
-pindakaas-derive = { version = "0.1.0", path = "../pindakaas-derive", optional = true }
+pindakaas-derive = { version = "0.1.1", path = "../pindakaas-derive", optional = true }
 pindakaas-intel-sat = { version = "0.1.0", path = "../pindakaas-intel-sat", optional = true }
 pindakaas-kissat = { version = "0.1.0", path = "../pindakaas-kissat", optional = true }
 splr = { version = "0.17", optional = true }

--- a/crates/pyndakaas/CHANGELOG.md
+++ b/crates/pyndakaas/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.1.0...pyndakaas-v0.1.1) - 2025-07-24
+
+### Other
+
+- update pyo3 requirement from 0.24.0 to 0.25.1 ([#129](https://github.com/pindakaashq/pindakaas/pull/129))
+
 ## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pyndakaas-v0.1.0) - 2025-07-08
 
 ### Added

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyndakaas"
 description = "Python bindings for the pindakaas crate"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 authors.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.14.0"
-pindakaas = { version = "0.1.0", path = "../pindakaas" }
+pindakaas = { version = "0.1.1", path = "../pindakaas" }
 pyo3 = "0.25.1"
 
 [lints]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,8 +5,3 @@ release_always = false
 [[package]]
 name = "pindakaas"
 publish_all_features = true
-
-[[package]]
-name = "pyndakaas"
-publish = false
-semver_check = false


### PR DESCRIPTION



## 🤖 New release

* `pindakaas-derive`: 0.1.0 -> 0.1.1
* `pyndakaas`: 0.1.0 -> 0.1.1
* `pindakaas`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `pindakaas-derive`

<blockquote>

## [0.1.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-derive-v0.1.0...pindakaas-derive-v0.1.1) - 2025-07-24

### Other

- *(pindakaas-derive)* update darling requirement from 0.20 to 0.21 ([#128](https://github.com/pindakaashq/pindakaas/pull/128))
</blockquote>

## `pyndakaas`

<blockquote>

## [0.1.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.1.0...pyndakaas-v0.1.1) - 2025-07-24

### Other

- update pyo3 requirement from 0.24.0 to 0.25.1 ([#129](https://github.com/pindakaashq/pindakaas/pull/129))
</blockquote>

## `pindakaas`

<blockquote>

## [0.1.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.1.0...pindakaas-v0.1.1) - 2025-07-24

### Other

- updated the following local packages: pindakaas-derive
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).