### PR TITLE
Install local version on CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -56,12 +56,11 @@ jobs:
         shell: bash
         run: |
           set -e
-          cd crates/pyndakaas
           python3 -m venv .venv
           source .venv/bin/activate
           pip install . --find-links dist --force-reinstall
           pip install pytest
-          pytest
+          cd crates/pyndakaas && pytest
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') && matrix.platform.target != 'ppc64' }}
         uses: uraimo/run-on-arch-action@v3
@@ -75,9 +74,8 @@ jobs:
             pip3 install -U pip pytest
           run: |
             set -e
-            cd crates/pyndakaas
             pip3 install . --find-links dist --force-reinstall
-            pytest
+            cd crates/pyndakaas && pytest
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -119,12 +117,11 @@ jobs:
           run: |
             set -e
             apk add py3-pip py3-virtualenv
-            cd crates/pyndakaas
             python3 -m virtualenv .venv
             source .venv/bin/activate
             pip install . --no-index --find-links dist --force-reinstall
             pip install pytest
-            pytest
+            cd crates/pyndakaas && pytest
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') }}
         uses: uraimo/run-on-arch-action@v3
@@ -136,12 +133,11 @@ jobs:
             apk add py3-virtualenv
           run: |
             set -e
-            cd crates/pyndakaas
             python3 -m virtualenv .venv
             source .venv/bin/activate
             pip install . --find-links dist --force-reinstall
             pip install pytest
-            pytest
+            cd crates/pyndakaas && pytest
   windows:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -175,12 +171,11 @@ jobs:
         shell: bash
         run: |
           set -e
-          cd crates/pyndakaas
           python3 -m venv .venv
           source .venv/Scripts/activate
           pip install . --find-links dist --force-reinstall
           pip install pytest
-          pytest
+          cd crates/pyndakaas && pytest
   macos:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -211,12 +206,11 @@ jobs:
       - name: pytest
         run: |
           set -e
-          cd crates/pyndakaas
           python3 -m venv .venv
           source .venv/bin/activate
           pip install . --find-links dist --force-reinstall
           pip install pytest
-          pytest
+          cd crates/pyndakaas && pytest
   sdist:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,9 +58,10 @@ jobs:
           set -e
           python3 -m venv .venv
           source .venv/bin/activate
+          cd crates/pyndakaas
           pip install . --find-links dist --force-reinstall
           pip install pytest
-          cd crates/pyndakaas && pytest
+          pytest
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') && matrix.platform.target != 'ppc64' }}
         uses: uraimo/run-on-arch-action@v3
@@ -74,8 +75,9 @@ jobs:
             pip3 install -U pip pytest
           run: |
             set -e
+            cd crates/pyndakaas
             pip3 install . --find-links dist --force-reinstall
-            cd crates/pyndakaas && pytest
+            pytest
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -119,9 +121,10 @@ jobs:
             apk add py3-pip py3-virtualenv
             python3 -m virtualenv .venv
             source .venv/bin/activate
+            cd crates/pyndakaas
             pip install . --no-index --find-links dist --force-reinstall
             pip install pytest
-            cd crates/pyndakaas && pytest
+            pytest
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') }}
         uses: uraimo/run-on-arch-action@v3
@@ -135,9 +138,10 @@ jobs:
             set -e
             python3 -m virtualenv .venv
             source .venv/bin/activate
+            cd crates/pyndakaas
             pip install . --find-links dist --force-reinstall
             pip install pytest
-            cd crates/pyndakaas && pytest
+            pytest
   windows:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -173,9 +177,10 @@ jobs:
           set -e
           python3 -m venv .venv
           source .venv/Scripts/activate
+          cd crates/pyndakaas
           pip install . --find-links dist --force-reinstall
           pip install pytest
-          cd crates/pyndakaas && pytest
+          pytest
   macos:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -208,9 +213,10 @@ jobs:
           set -e
           python3 -m venv .venv
           source .venv/bin/activate
+          cd crates/pyndakaas
           pip install . --find-links dist --force-reinstall
           pip install pytest
-          cd crates/pyndakaas && pytest
+          pytest
   sdist:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -4,7 +4,6 @@
 #    maturin generate-ci --manifest-path crates/pyndakaas/Cargo.toml github --pytest
 #
 name: CI
-
 on:
   push:
     branches:
@@ -13,10 +12,8 @@ on:
       - "pyndakaas-v*"
   pull_request:
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   linux:
     runs-on: ${{ matrix.platform.runner }}
@@ -59,11 +56,12 @@ jobs:
         shell: bash
         run: |
           set -e
+          cd crates/pyndakaas
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install pindakaas --find-links dist --force-reinstall
+          pip install . --find-links dist --force-reinstall
           pip install pytest
-          cd crates/pyndakaas && pytest
+          pytest
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') && matrix.platform.target != 'ppc64' }}
         uses: uraimo/run-on-arch-action@v3
@@ -77,9 +75,9 @@ jobs:
             pip3 install -U pip pytest
           run: |
             set -e
-            pip3 install pindakaas --find-links dist --force-reinstall
-            cd crates/pyndakaas && pytest
-
+            cd crates/pyndakaas
+            pip3 install . --find-links dist --force-reinstall
+            pytest
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -121,11 +119,12 @@ jobs:
           run: |
             set -e
             apk add py3-pip py3-virtualenv
+            cd crates/pyndakaas
             python3 -m virtualenv .venv
             source .venv/bin/activate
-            pip install pindakaas --no-index --find-links dist --force-reinstall
+            pip install . --no-index --find-links dist --force-reinstall
             pip install pytest
-            cd crates/pyndakaas && pytest
+            pytest
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') }}
         uses: uraimo/run-on-arch-action@v3
@@ -137,12 +136,12 @@ jobs:
             apk add py3-virtualenv
           run: |
             set -e
+            cd crates/pyndakaas
             python3 -m virtualenv .venv
             source .venv/bin/activate
+            pip install . --find-links dist --force-reinstall
             pip install pytest
-            pip install pindakaas --find-links dist --force-reinstall
-            cd crates/pyndakaas && pytest
-
+            pytest
   windows:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -176,12 +175,12 @@ jobs:
         shell: bash
         run: |
           set -e
+          cd crates/pyndakaas
           python3 -m venv .venv
           source .venv/Scripts/activate
-          pip install pindakaas --find-links dist --force-reinstall
+          pip install . --find-links dist --force-reinstall
           pip install pytest
-          cd crates/pyndakaas && pytest
-
+          pytest
   macos:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -212,12 +211,12 @@ jobs:
       - name: pytest
         run: |
           set -e
+          cd crates/pyndakaas
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install pindakaas --find-links dist --force-reinstall
+          pip install . --find-links dist --force-reinstall
           pip install pytest
-          cd crates/pyndakaas && pytest
-
+          pytest
   sdist:
     runs-on: ubuntu-latest
     steps:
@@ -234,7 +233,6 @@ jobs:
         with:
           name: wheels-sdist
           path: dist
-
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -59,7 +59,7 @@ jobs:
           python3 -m venv .venv
           source .venv/bin/activate
           cd crates/pyndakaas
-          pip install . --find-links dist --force-reinstall
+          pip install . --find-links ../../dist --force-reinstall
           pip install pytest
           pytest
       - name: pytest
@@ -76,7 +76,7 @@ jobs:
           run: |
             set -e
             cd crates/pyndakaas
-            pip3 install . --find-links dist --force-reinstall
+            pip3 install . --find-links ../../dist --force-reinstall
             pytest
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
@@ -122,7 +122,7 @@ jobs:
             python3 -m virtualenv .venv
             source .venv/bin/activate
             cd crates/pyndakaas
-            pip install . --no-index --find-links dist --force-reinstall
+            pip install . --no-index --find-links ../../dist --force-reinstall
             pip install pytest
             pytest
       - name: pytest
@@ -139,7 +139,7 @@ jobs:
             python3 -m virtualenv .venv
             source .venv/bin/activate
             cd crates/pyndakaas
-            pip install . --find-links dist --force-reinstall
+            pip install . --find-links ../../dist --force-reinstall
             pip install pytest
             pytest
   windows:
@@ -178,7 +178,7 @@ jobs:
           python3 -m venv .venv
           source .venv/Scripts/activate
           cd crates/pyndakaas
-          pip install . --find-links dist --force-reinstall
+          pip install . --find-links ../../dist --force-reinstall
           pip install pytest
           pytest
   macos:
@@ -214,7 +214,7 @@ jobs:
           python3 -m venv .venv
           source .venv/bin/activate
           cd crates/pyndakaas
-          pip install . --find-links dist --force-reinstall
+          pip install . --find-links ../../dist --force-reinstall
           pip install pytest
           pytest
   sdist:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -118,7 +118,7 @@ jobs:
           options: -v ${{ github.workspace }}:/io -w /io
           run: |
             set -e
-            apk add py3-pip py3-virtualenv
+            apk add py3-pip py3-virtualenv build-base
             python3 -m virtualenv .venv
             source .venv/bin/activate
             cd crates/pyndakaas


### PR DESCRIPTION
I believe the CI is just installing and testing the released version of the pindakaas python interface from Pypi, rather than building the local one.
