### PR TITLE
refactor(pindakaas): remove iset dependency

### DIFF
--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
-iset = "=0.3.0"
 itertools = "0.14"
 rustc-hash = "2.0"
+rangelist = "0.3.1"
 
 # Dynamically load solver libraries (through IPASIR interfaces)
 libloading = { version = "0.8", optional = true }

--- a/crates/pindakaas/src/bool_linear.rs
+++ b/crates/pindakaas/src/bool_linear.rs
@@ -1,14 +1,13 @@
 use std::{
 	cell::RefCell,
-	cmp::{max, min},
-	collections::{BTreeSet, VecDeque},
+	cmp::{max, min, Ordering},
+	collections::VecDeque,
 	fmt::{self, Display},
 	iter::once,
 	ops::{Add, AddAssign, Deref, DerefMut, Mul, MulAssign, Neg, Range, Sub, SubAssign},
 	rc::Rc,
 };
 
-use iset::IntervalMap;
 use itertools::Itertools;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
@@ -491,55 +490,73 @@ impl BddEncoder {
 		i: usize,
 		xs: &Vec<IntVarEnc>,
 		sum: Coeff,
-		ws: &mut Vec<IntervalMap<Coeff, BddNode>>,
+		ws: &mut Vec<Vec<(Range<Coeff>, BddNode)>>,
 	) -> (Range<Coeff>, BddNode) {
-		match &ws[i].overlap(sum).collect_vec()[..] {
-			[] => {
-				let views = xs[i]
-					.dom()
-					.iter(..)
-					.map(|v| v.end - 1)
-					.map(|v| (v, Self::bdd(i + 1, xs, sum + v, ws)))
-					.collect_vec();
-
-				// TODO could we check whether a domain value of x always leads to gaps?
-				let is_gap = views.iter().all(|(_, (_, v))| v == &BddNode::Gap);
-				// TODO without checking actual Val identity, could we miss when the next layer has two
-				// adjacent nodes that are both views on the same node at the layer below?
-				let view = (views.iter().map(|(_, (iv, _))| iv).all_equal())
-					.then(|| views.first().unwrap().1 .0.end - 1);
-
-				let interval = views
-					.into_iter()
-					.map(|(v, (interval, _))| (interval.start - v)..(interval.end - v))
-					.reduce(|a, b| max(a.start, b.start)..min(a.end, b.end))
-					.unwrap();
-
-				let node = if is_gap {
-					BddNode::Gap
-				} else if let Some(view) = view {
-					BddNode::View(view)
-				} else {
-					BddNode::Val
-				};
-
-				let new_interval_inserted = ws[i].insert(interval.clone(), node.clone()).is_none();
-				debug_assert!(
-					new_interval_inserted,
-					"Duplicate interval {interval:?} inserted into {ws:?} layer {i}"
-				);
-				(interval, node)
+		// See if the node for `sum` is already available
+		if let Ok(pos) = ws[i].binary_search_by(|(r, _)| {
+			if r.contains(&sum) {
+				Ordering::Equal
+			} else if r.end <= sum {
+				Ordering::Less
+			} else {
+				Ordering::Greater
 			}
-			[(a, node)] => (a.clone(), (*node).clone()),
-			_ => panic!("ROBDD intervals should be disjoint, but were {:?}", ws[i]),
+		}) {
+			return ws[i][pos].clone();
 		}
+
+		let views = xs[i]
+			.dom()
+			.iter()
+			.flatten()
+			.map(|v| (v, Self::bdd(i + 1, xs, sum + v, ws)))
+			.collect_vec();
+
+		// TODO could we check whether a domain value of x always leads to gaps?
+		let is_gap = views.iter().all(|(_, (_, v))| v == &BddNode::Gap);
+		// TODO without checking actual Val identity, could we miss when the next layer has two
+		// adjacent nodes that are both views on the same node at the layer below?
+		let view = (views.iter().map(|(_, (iv, _))| iv).all_equal())
+			.then(|| views.first().unwrap().1 .0.end - 1);
+
+		let interval = views
+			.into_iter()
+			.map(|(v, (interval, _))| (interval.start - v)..(interval.end - v))
+			.reduce(|a, b| max(a.start, b.start)..min(a.end, b.end))
+			.unwrap();
+
+		let node = if is_gap {
+			BddNode::Gap
+		} else if let Some(view) = view {
+			BddNode::View(view)
+		} else {
+			BddNode::Val
+		};
+
+		let pos = match ws[i].binary_search_by_key(&interval.start, |(r, _)| r.start) {
+			Ok(i) | Err(i) => i,
+		};
+		ws[i].insert(pos, (interval.clone(), node.clone()));
+		debug_assert!(
+			pos == 0 || ws[i][pos - 1].0.end <= ws[i][pos].0.start,
+			"Overlapping interval {interval:?} (overlapping with {:?}) inserted into {:?}",
+			ws[i][pos - 1].0,
+			ws[i]
+		);
+		debug_assert!(
+			pos + 1 == ws[i].len() || ws[i][pos].0.end <= ws[i][pos + 1].0.start,
+			"Overlapping interval {interval:?} (overlapping with {:?}) inserted into {:?}",
+			ws[i][pos + 1].1,
+			ws[i]
+		);
+		(interval, node)
 	}
 
 	fn construct_bdd(
 		xs: &Vec<IntVarEnc>,
 		cmp: &LimitComp,
 		k: PosCoeff,
-	) -> Vec<IntervalMap<Coeff, BddNode>> {
+	) -> Vec<Vec<(Range<Coeff>, BddNode)>> {
 		let k = *k;
 
 		let bounds = xs
@@ -562,7 +579,7 @@ impl BddEncoder {
 
 		let inf = xs.iter().fold(0, |a, x| a + x.ub()) + 1;
 
-		let mut ws = margins
+		let mut ws: Vec<Vec<(Range<Coeff>, BddNode)>> = margins
 			.into_iter()
 			.rev()
 			.chain(once((k, k)))
@@ -584,13 +601,20 @@ impl BddEncoder {
 				.collect()
 			})
 			.collect();
+		debug_assert!(
+			ws.iter().all(|layer| layer
+				.iter()
+				.tuple_windows()
+				.all(|((a, _), (b, _))| a.end <= b.end)),
+			"layers must be sorted and non-overlapping"
+		);
 
 		let _ = Self::bdd(0, xs, 0, &mut ws);
 		ws
 	}
 }
 
-impl<DB: ClauseDatabase + ?Sized> Encoder<DB, NormalizedBoolLinear> for BddEncoder {
+impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, NormalizedBoolLinear> for BddEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "bdd_encoder", skip_all, fields(constraint = lin.trace_print()))
@@ -619,7 +643,7 @@ impl<DB: ClauseDatabase + ?Sized> Encoder<DB, NormalizedBoolLinear> for BddEncod
 				Rc::new(RefCell::new({
 					let mut y = model.new_var(
 						nodes
-							.into_iter(..)
+							.into_iter()
 							.filter_map(|(iv, node)| match node {
 								BddNode::Gap => None,
 								BddNode::Val => Some(iv.end - 1),
@@ -629,6 +653,7 @@ impl<DB: ClauseDatabase + ?Sized> Encoder<DB, NormalizedBoolLinear> for BddEncod
 									Some(val)
 								}
 							})
+							.map(|v| v..=v)
 							.collect(),
 						self.add_consistency,
 					);
@@ -666,7 +691,7 @@ impl BoolLinAggregator {
 		any(feature = "tracing", test),
 		tracing::instrument(name = "aggregator", skip_all, fields(constraint = lin.trace_print()))
 	)]
-	pub fn aggregate<DB: ClauseDatabase + ?Sized>(
+	pub fn aggregate<DB: ClauseDatabase + AsDynClauseDatabase>(
 		&self,
 		db: &mut DB,
 		lin: &BoolLinear,
@@ -1627,21 +1652,23 @@ impl Display for LimitComp {
 }
 
 impl<Enc, Agg> LinearEncoder<Enc, Agg> {
-	pub fn add_linear_aggregater(&mut self, agg: Agg) -> &mut Self {
+	pub fn add_linear_aggregator(&mut self, agg: Agg) -> &mut Self {
 		self.agg = agg;
 		self
 	}
+
 	pub fn add_variant_encoder(&mut self, enc: Enc) -> &mut Self {
 		self.enc = enc;
 		self
 	}
+
 	pub fn new(enc: Enc, agg: Agg) -> Self {
 		Self { enc, agg }
 	}
 }
 
-impl<DB: ClauseDatabase + ?Sized, Enc: Encoder<DB, BoolLinVariant>> Encoder<DB, BoolLinear>
-	for LinearEncoder<Enc>
+impl<DB: ClauseDatabase + AsDynClauseDatabase, Enc: Encoder<DB, BoolLinVariant>>
+	Encoder<DB, BoolLinear> for LinearEncoder<Enc>
 {
 	#[cfg_attr(
 		any(feature = "tracing", test),
@@ -1847,7 +1874,7 @@ impl SwcEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase + ?Sized> Encoder<DB, NormalizedBoolLinear> for SwcEncoder {
+impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, NormalizedBoolLinear> for SwcEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "swc_encoder", skip_all, fields(constraint = lin.trace_print()))
@@ -1868,7 +1895,7 @@ impl<DB: ClauseDatabase + ?Sized> Encoder<DB, NormalizedBoolLinear> for SwcEncod
 		let ys = once(model.new_constant(0))
 			.chain(
 				(1..n)
-					.map(|_| model.new_var((-(*lin.k)..=0).collect(), self.add_consistency))
+					.map(|_| model.new_var((-(*lin.k)..=0).into(), self.add_consistency))
 					.take(n),
 			)
 			.collect_vec()
@@ -1928,16 +1955,16 @@ impl TotalizerEncoder {
 					[left, right] => {
 						let at_root = layer.len() == 2;
 						let dom = if at_root {
-							BTreeSet::from([k])
+							(k..=k).into()
 						} else {
 							left.borrow()
 								.dom
 								.iter()
-								.cartesian_product(right.borrow().dom.iter())
-								.map(|(&a, &b)| a + b)
+								.flatten()
+								.cartesian_product(right.borrow().dom.iter().flatten())
+								.map(|(a, b)| a + b)
 								.filter(|&d| d <= k)
-								.sorted()
-								.dedup()
+								.map(|v| v..=v)
 								.collect()
 						};
 						let parent =
@@ -1965,7 +1992,9 @@ impl TotalizerEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase + ?Sized> Encoder<DB, NormalizedBoolLinear> for TotalizerEncoder {
+impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, NormalizedBoolLinear>
+	for TotalizerEncoder
+{
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "totalizer_encoder", skip_all, fields(constraint = lin.trace_print()))
@@ -2970,7 +2999,7 @@ mod tests {
 		let mut agg = BoolLinAggregator::default();
 		let _ = agg.sort_same_coefficients(SortedEncoder::default(), 3);
 		let mut encoder = LinearEncoder::<StaticLinEncoder<TotalizerEncoder>>::default();
-		let _ = encoder.add_linear_aggregater(agg);
+		let _ = encoder.add_linear_aggregator(agg);
 		let con = BoolLinear::new(
 			BoolLinExp::from_slices(&[3, 3, 1, 1, 3], &vars),
 			Comparator::GreaterEq,

--- a/crates/pindakaas/src/cardinality.rs
+++ b/crates/pindakaas/src/cardinality.rs
@@ -3,7 +3,7 @@ use crate::{
 	cardinality_one::CardinalityOne,
 	integer::IntVarEnc,
 	sorted::{Sorted, SortedEncoder},
-	Checker, ClauseDatabase, Coeff, Encoder, Lit, Result, Valuation,
+	AsDynClauseDatabase, Checker, ClauseDatabase, Coeff, Encoder, Lit, Result, Valuation,
 };
 
 // local marker trait, to ensure the previous definition only applies within this crate
@@ -95,7 +95,7 @@ impl Default for SortingNetworkEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase + ?Sized> Encoder<DB, Cardinality> for SortingNetworkEncoder {
+impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, Cardinality> for SortingNetworkEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "sorting_network_encoder", skip_all, fields(constraint = card.trace_print()))

--- a/crates/pindakaas/src/helpers.rs
+++ b/crates/pindakaas/src/helpers.rs
@@ -53,46 +53,9 @@ pub(crate) mod opt_field;
 
 use itertools::Itertools;
 pub(crate) use new_named_lit;
-use rustc_hash::FxHashSet;
 
-use crate::{
-	bool_linear::PosCoeff, integer::IntVar, ClauseDatabase, ClauseDatabaseTools, Coeff, Lit, Result,
-};
+use crate::{bool_linear::PosCoeff, integer::IntVar, ClauseDatabase, Coeff};
 
-const FILTER_TRIVIAL_CLAUSES: bool = false;
-
-/// Adds clauses for a DNF formula (disjunction of conjunctions)
-/// Ex. (a /\ -b) \/ c == a \/ c /\ -b \/ c
-/// If any disjunction is empty, this satisfies the whole formula. If any element contains the empty conjunction, that element is falsified in the final clause.
-pub(crate) fn add_clauses_for<DB: ClauseDatabase + ?Sized>(
-	db: &mut DB,
-	expression: Vec<Vec<Vec<Lit>>>,
-) -> Result {
-	// TODO doctor out type of expression (clauses containing conjunctions?)
-
-	for cls in expression
-		.into_iter()
-		.map(|cls| cls.into_iter())
-		.multi_cartesian_product()
-	{
-		let cls = cls.concat(); // filter out [] (empty conjunctions?) of the clause
-		if FILTER_TRIVIAL_CLAUSES {
-			let mut lits = FxHashSet::default();
-			if cls.iter().any(|&lit| {
-				if lits.contains(&(!lit)) {
-					true
-				} else {
-					let _ = lits.insert(lit);
-					false
-				}
-			}) {
-				continue;
-			}
-		}
-		db.add_clause(cls)?;
-	}
-	Ok(())
-}
 /// Convert `k` to unsigned binary in `bits`
 pub(crate) fn as_binary(k: PosCoeff, bits: Option<u32>) -> Vec<bool> {
 	let bits = bits.unwrap_or_else(|| IntVar::required_bits(0, *k));
@@ -111,21 +74,6 @@ pub(crate) fn is_powers_of_two<I: IntoIterator<Item = Coeff>>(coefs: I) -> bool 
 		it.all(|(i, c)| c == (TWO.pow(i as u32) * mult))
 	} else {
 		false
-	}
-}
-
-/// Negates CNF (flipping between empty clause and formula)
-pub(crate) fn negate_cnf(clauses: Vec<Vec<Lit>>) -> Vec<Vec<Lit>> {
-	if clauses.is_empty() {
-		vec![vec![]]
-	} else if clauses.contains(&vec![]) {
-		vec![]
-	} else {
-		assert!(clauses.len() == 1);
-		clauses
-			.into_iter()
-			.map(|clause| clause.into_iter().map(|lit| !lit).collect())
-			.collect()
 	}
 }
 

--- a/crates/pindakaas/src/integer.rs
+++ b/crates/pindakaas/src/integer.rs
@@ -1,25 +1,22 @@
 use std::{
 	cell::RefCell,
 	cmp::{max, min},
-	collections::BTreeSet,
 	fmt::{self, Display},
 	iter::once,
-	ops::Range,
+	ops::Bound,
 	rc::Rc,
 };
 
-use iset::{interval_map, interval_set, IntervalMap, IntervalSet};
 use itertools::Itertools;
-use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use rangelist::{IntervalIterator, RangeList};
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use crate::{
 	bool_linear::{BoolLinExp, LimitComp, Part, PosCoeff},
-	helpers::{
-		add_clauses_for, as_binary, is_powers_of_two, negate_cnf, new_named_lit,
-		unsigned_binary_range_ub,
-	},
-	BoolVal, Checker, ClauseDatabase, ClauseDatabaseTools, Coeff, Encoder, Lit, Result,
-	Unsatisfiable, Valuation,
+	helpers::{as_binary, is_powers_of_two, new_named_lit, unsigned_binary_range_ub},
+	propositional_logic::{Formula, TseitinEncoder},
+	AsDynClauseDatabase, BoolVal, Checker, ClauseDatabase, ClauseDatabaseTools, Coeff, Encoder,
+	Lit, Result, Unsatisfiable, Valuation,
 };
 
 const COUPLE_DOM_PART_TO_ORD: bool = false;
@@ -45,7 +42,7 @@ pub(crate) struct ImplicationChainEncoder {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct IntVar {
 	pub(crate) id: usize,
-	pub(crate) dom: BTreeSet<Coeff>,
+	pub(crate) dom: RangeList<Coeff>,
 	add_consistency: bool,
 	pub(crate) views: FxHashMap<Coeff, (usize, Coeff)>,
 }
@@ -67,7 +64,8 @@ pub(crate) enum IntVarEnc {
 
 #[derive(Debug, Clone)]
 pub(crate) struct IntVarOrd {
-	pub(crate) xs: IntervalMap<Coeff, Lit>,
+	pub(crate) dom: RangeList<Coeff>,
+	pub(crate) xs: Vec<Lit>,
 	pub(crate) lbl: String,
 }
 
@@ -95,20 +93,22 @@ pub(crate) struct TernLeConstraint<'a> {
 #[derive(Debug, Default)]
 pub(crate) struct TernLeEncoder {}
 
-pub(crate) fn display_dom(dom: &BTreeSet<Coeff>) -> String {
+pub(crate) fn display_dom(dom: &RangeList<Coeff>) -> String {
 	const ELIPSIZE: usize = 8;
-	let (lb, ub) = (*dom.first().unwrap(), *dom.last().unwrap());
-	if dom.len() > ELIPSIZE && dom.len() == (ub - lb + 1) as usize {
-		format!("{}..{}", dom.first().unwrap(), dom.last().unwrap())
-	} else if dom.len() > ELIPSIZE {
+	let card = dom.card().unwrap();
+	let lb = *dom.lower_bound().unwrap();
+	let ub = *dom.upper_bound().unwrap();
+	if card > ELIPSIZE && dom.iter().len() == 1 {
+		format!("{}..{}", lb, ub)
+	} else if card > ELIPSIZE {
 		format!(
 			"{{{},..,{ub}}} ({}|{})",
-			dom.iter().take(ELIPSIZE).join(","),
-			dom.len(),
+			dom.iter().flatten().take(ELIPSIZE).join(","),
+			card,
 			IntVar::required_bits(lb, ub)
 		)
 	} else {
-		format!("{{{}}}", dom.iter().join(","))
+		format!("{{{}}}", dom.iter().flatten().join(","))
 	}
 }
 
@@ -249,28 +249,29 @@ pub(crate) fn log_enc_add_<DB: ClauseDatabase + ?Sized>(
 		}
 	}
 }
-pub(crate) fn ord_plus_ord_le_ord_sparse_dom(
-	a: Vec<Coeff>,
-	b: Vec<Coeff>,
+
+pub(crate) fn ord_plus_ord_le_ord_sparse_dom<I1, I2>(
+	a: I1,
+	b: I2,
 	l: Coeff,
 	u: Coeff,
-) -> IntervalSet<Coeff> {
-	// TODO optimize by dedup (if already sorted?)
-	FxHashSet::<Coeff>::from_iter(a.iter().flat_map(|a| {
-		b.iter().filter_map(move |b| {
-			// TODO refactor: use then_some when stabilized
-			if *a + *b >= l && *a + *b <= u {
-				Some(*a + *b)
+) -> RangeList<Coeff>
+where
+	I1: IntoIterator<Item = Coeff>,
+	I2: IntoIterator<Item = Coeff>,
+	I2::IntoIter: Clone,
+{
+	a.into_iter()
+		.cartesian_product(b)
+		.filter_map(|(a, b)| {
+			if a + b >= l && a + b <= u {
+				Some(a + b)
 			} else {
 				None
 			}
 		})
-	}))
-	.into_iter()
-	.sorted()
-	.tuple_windows()
-	.map(|(a, b)| (a + 1)..(b + 1))
-	.collect::<IntervalSet<_>>()
+		.map(|v| v..=v)
+		.collect()
 }
 
 impl Checker for ImplicationChainConstraint {
@@ -298,31 +299,34 @@ impl ImplicationChainEncoder {
 }
 
 impl IntVar {
-	fn encode<DB: ClauseDatabase + ?Sized>(
+	fn encode<DB: ClauseDatabase + AsDynClauseDatabase>(
 		&self,
 		db: &mut DB,
 		views: &mut FxHashMap<(usize, Coeff), Lit>,
 		prefer_order: bool,
 	) -> IntVarEnc {
 		if self.size() == 1 {
-			IntVarEnc::Const(*self.dom.first().unwrap())
+			IntVarEnc::Const(*self.dom.lower_bound().unwrap())
 		} else {
 			let x = if prefer_order {
-				let dom = self
+				let views = self
 					.dom
 					.iter()
-					.sorted()
-					.cloned()
-					.tuple_windows()
-					.map(|(a, b)| (a + 1)..(b + 1))
-					.map(|v| (v.clone(), views.get(&(self.id, v.end - 1)).cloned()))
-					.collect::<IntervalMap<_, _>>();
-				IntVarEnc::Ord(IntVarOrd::from_views(db, dom, "x".to_owned()))
+					.flatten()
+					.skip(1)
+					.map(|v| views.get(&(self.id, v)).cloned())
+					.collect();
+				IntVarEnc::Ord(IntVarOrd::from_views(
+					db,
+					self.dom.clone(),
+					views,
+					"x".to_owned(),
+				))
 			} else {
 				let y = IntVarBin::from_bounds(
 					db,
-					*self.dom.first().unwrap(),
-					*self.dom.last().unwrap(),
+					*self.dom.lower_bound().unwrap(),
+					*self.dom.upper_bound().unwrap(),
 					"x".to_owned(),
 				);
 				IntVarEnc::Bin(y)
@@ -332,42 +336,42 @@ impl IntVar {
 				x.consistent(db).unwrap();
 			}
 
-			for view in self
+			for (view, f) in self
 				.views
 				.iter()
-				.map(|(c, (id, val))| ((*id, *val), x.geq(*c..(*c + 1))))
+				.map(|(c, (id, val))| ((*id, *val), x.geq(*c)))
 			{
 				// TODO refactor
-				if !view.1.is_empty() {
-					let _ = views.insert(view.0, view.1[0][0]);
+				if let Formula::Atom(BoolVal::Lit(l)) = f {
+					let _ = views.insert(view, l);
 				}
 			}
 			x
 		}
 	}
 
-	fn ge(&mut self, bound: &Coeff) {
-		self.dom = self.dom.split_off(bound);
+	fn ge(&mut self, bound: Coeff) {
+		self.dom = self.dom.intersect(&RangeList::from(bound..=Coeff::MAX));
 	}
 
-	pub(crate) fn lb(&self, c: &Coeff) -> Coeff {
-		*c * *(if c.is_negative() {
-			self.dom.last()
+	pub(crate) fn lb(&self, c: Coeff) -> Coeff {
+		c * if c.is_negative() {
+			self.dom.upper_bound()
 		} else {
-			self.dom.first()
-		})
+			self.dom.lower_bound()
+		}
 		.unwrap()
 	}
 
-	fn le(&mut self, bound: &Coeff) {
-		let _ = self.dom.split_off(&(*bound + 1));
+	fn le(&mut self, bound: Coeff) {
+		self.dom = self.dom.intersect(&RangeList::from(Coeff::MIN..=bound));
 	}
 
 	fn prefer_order(&self, cutoff: Option<Coeff>) -> bool {
 		match cutoff {
 			None => true,
 			Some(0) => false,
-			Some(cutoff) => (self.dom.len() as Coeff) < cutoff,
+			Some(cutoff) => (self.dom.card().unwrap() as Coeff) < cutoff,
 		}
 	}
 
@@ -381,15 +385,15 @@ impl IntVar {
 	}
 
 	pub(crate) fn size(&self) -> usize {
-		self.dom.len()
+		self.dom.card().unwrap()
 	}
 
-	pub(crate) fn ub(&self, c: &Coeff) -> Coeff {
-		*c * *(if c.is_negative() {
-			self.dom.first()
+	pub(crate) fn ub(&self, c: Coeff) -> Coeff {
+		c * if c.is_negative() {
+			self.dom.lower_bound()
 		} else {
-			self.dom.last()
-		})
+			self.dom.upper_bound()
+		}
 		.unwrap()
 	}
 }
@@ -401,7 +405,7 @@ impl Display for IntVar {
 }
 
 impl IntVarBin {
-	pub(crate) fn add<DB: ClauseDatabase + ?Sized>(
+	pub(crate) fn add<DB: ClauseDatabase + AsDynClauseDatabase>(
 		&self,
 		db: &mut DB,
 		encoder: &TernLeEncoder,
@@ -437,7 +441,10 @@ impl IntVarBin {
 		}
 	}
 
-	pub(crate) fn consistent<DB: ClauseDatabase + ?Sized>(&self, db: &mut DB) -> Result {
+	pub(crate) fn consistent<DB: ClauseDatabase + AsDynClauseDatabase>(
+		&self,
+		db: &mut DB,
+	) -> Result {
 		let encoder = TernLeEncoder::default();
 		if !GROUND_BINARY_AT_LB {
 			encoder.encode(
@@ -465,9 +472,10 @@ impl IntVarBin {
 		todo!()
 	}
 
-	fn dom(&self) -> IntervalSet<Coeff> {
-		(self.lb..=self.ub).map(|i| i..(i + 1)).collect()
+	fn dom(&self) -> RangeList<Coeff> {
+		(self.lb..=self.ub).into()
 	}
+
 	// TODO change to with_label or something
 	pub(crate) fn from_bounds<DB: ClauseDatabase + ?Sized>(
 		db: &mut DB,
@@ -500,14 +508,14 @@ impl IntVarBin {
 		}
 	}
 
-	pub(crate) fn geq(&self, v: Range<Coeff>) -> Vec<Vec<Lit>> {
+	pub(crate) fn geq(&self, v: Coeff) -> Formula<BoolVal> {
 		self.ineq(v, true)
 	}
 
-	fn ineq(&self, v: Range<Coeff>, geq: bool) -> Vec<Vec<Lit>> {
+	fn ineq(&self, v: Coeff, geq: bool) -> Formula<BoolVal> {
 		// TODO could *maybe* be domain lb/ub
 		let v = if GROUND_BINARY_AT_LB {
-			(v.start - self.lb())..(v.end - self.lb())
+			v - self.lb()
 		} else {
 			v
 		};
@@ -516,34 +524,44 @@ impl IntVarBin {
 		let range_lb = 0;
 		let range_ub = unsigned_binary_range_ub(self.lits() as u32);
 
-		let range = max(range_lb - 1, v.start)..min(v.end, range_ub + 1 + 1);
-		range
-			.filter_map(|v| {
-				let v = if geq { v - 1 } else { v + 1 };
-				if v < range_lb {
-					(!geq).then_some(vec![])
-				} else if v > range_ub {
-					geq.then_some(vec![])
-				} else {
-					Some(
-						as_binary(PosCoeff::new(v), Some(self.lits() as u32))
-							.into_iter()
-							.zip(self.xs.iter())
-							// if >=, find 0s, if <=, find 1s
-							.filter_map(|(b, x)| (b != geq).then_some(x))
-							.map(|&x| if geq { x } else { !x })
-							.collect(),
-					)
+		if v <= range_lb {
+			Formula::Atom(BoolVal::Const(geq))
+		} else if v >= range_ub {
+			Formula::Atom(BoolVal::Const(!geq))
+		} else {
+			// generalized from `lex_leq_const`
+			let v = as_binary(PosCoeff::new(v), Some(self.lits() as u32));
+			let mut conj = Vec::new();
+			for (i, _) in v.iter().enumerate().filter(|(_, &v)| v == geq) {
+				let mut disj = Vec::new();
+				for (j, _) in v
+					.iter()
+					.enumerate()
+					.skip(i)
+					.filter(|&(j, &v)| j == i || v != geq)
+				{
+					let lit = self.xs[j];
+					disj.push(Formula::Atom(BoolVal::Lit(if geq { lit } else { !lit })));
 				}
-			})
-			.collect()
+				conj.push(if disj.len() == 1 {
+					disj.pop().unwrap()
+				} else {
+					Formula::Or(disj)
+				});
+			}
+			if conj.len() == 1 {
+				conj.pop().unwrap()
+			} else {
+				Formula::And(conj)
+			}
+		}
 	}
 
 	pub(crate) fn lb(&self) -> Coeff {
 		self.lb
 	}
 
-	pub(crate) fn leq(&self, v: Range<Coeff>) -> Vec<Vec<Lit>> {
+	pub(crate) fn leq(&self, v: Coeff) -> Formula<BoolVal> {
 		self.ineq(v, false)
 	}
 
@@ -562,14 +580,14 @@ impl Display for IntVarBin {
 			f,
 			"{}:B ∈ {} [{}]",
 			self.lbl,
-			display_dom(&self.dom().iter(..).map(|d| d.end - 1).collect()),
+			display_dom(&self.dom()),
 			self.lits()
 		)
 	}
 }
 
 impl IntVarEnc {
-	pub(crate) fn add<DB: ClauseDatabase + ?Sized>(
+	pub(crate) fn add<DB: ClauseDatabase + AsDynClauseDatabase>(
 		&self,
 		db: &mut DB,
 		encoder: &TernLeEncoder,
@@ -589,23 +607,26 @@ impl IntVarEnc {
 			(IntVarEnc::Const(a), IntVarEnc::Const(b)) => Ok(IntVarEnc::Const(*a + *b)),
 			// TODO only used in sorters which enforce the constraints later!
 			(IntVarEnc::Const(c), x) | (x, IntVarEnc::Const(c)) if (*c == 0) => Ok(x.clone()),
-			(IntVarEnc::Ord(x), IntVarEnc::Ord(y)) => Ok(IntVarEnc::Ord(IntVarOrd::from_syms(
+			(IntVarEnc::Ord(x), IntVarEnc::Ord(y)) => Ok(IntVarEnc::Ord(IntVarOrd::from_dom(
 				db,
 				ord_plus_ord_le_ord_sparse_dom(
-					x.dom().iter(..).map(|d| d.end - 1).collect(),
-					y.dom().iter(..).map(|d| d.end - 1).collect(),
+					x.dom().iter().flatten(),
+					y.dom().iter().flatten(),
 					lb,
 					ub,
 				),
 				format!("{}+{}", x.lbl, y.lbl),
 			))),
-			(IntVarEnc::Ord(x), IntVarEnc::Const(y)) | (IntVarEnc::Const(y), IntVarEnc::Ord(x)) => {
-				let xs =
-					x.xs.iter(..)
-						.map(|(c, l)| ((c.start + *y)..(c.end + *y), *l))
-						.collect();
+			(IntVarEnc::Ord(x), &IntVarEnc::Const(y))
+			| (&IntVarEnc::Const(y), IntVarEnc::Ord(x)) => {
+				let dom = x
+					.dom
+					.iter()
+					.map(|r| *r.start() + y..=*r.end() + y)
+					.collect();
 				Ok(IntVarOrd {
-					xs,
+					dom,
+					xs: x.xs.clone(),
 					lbl: format!("{}+{}", x.lbl, y),
 				}
 				.into())
@@ -641,7 +662,10 @@ impl IntVarEnc {
 		}
 	}
 
-	pub(crate) fn consistent<DB: ClauseDatabase + ?Sized>(&self, db: &mut DB) -> Result {
+	pub(crate) fn consistent<DB: ClauseDatabase + AsDynClauseDatabase>(
+		&self,
+		db: &mut DB,
+	) -> Result {
 		match self {
 			IntVarEnc::Ord(o) => o.consistent(db),
 			IntVarEnc::Bin(b) => b.consistent(db),
@@ -658,15 +682,15 @@ impl IntVarEnc {
 	}
 
 	/// Returns a partitioned domain
-	pub(crate) fn dom(&self) -> IntervalSet<Coeff> {
+	pub(crate) fn dom(&self) -> RangeList<Coeff> {
 		match self {
 			IntVarEnc::Ord(o) => o.dom(),
 			IntVarEnc::Bin(b) => b.dom(),
-			&IntVarEnc::Const(c) => interval_set!(c..(c + 1)),
+			&IntVarEnc::Const(c) => (c..=c).into(),
 		}
 	}
 	/// Constructs (one or more) IntVar `ys` for linear expression `xs` so that ∑ xs ≦ ∑ ys
-	pub(crate) fn from_part<DB: ClauseDatabase + ?Sized>(
+	pub(crate) fn from_part<DB: ClauseDatabase + AsDynClauseDatabase>(
 		db: &mut DB,
 		xs: &Part,
 		ub: PosCoeff,
@@ -686,40 +710,36 @@ impl IntVarEnc {
 					debug_assert!(coef <= *ub);
 					h.entry(coef).or_default().push(lit);
 				}
-
-				let dom = once((0, vec![]))
-					.chain(h)
-					.sorted_by(|(a, _), (b, _)| a.cmp(b))
-					.tuple_windows()
-					.map(|((prev, _), (coef, lits))| {
-						let interval = (prev + 1)..(coef + 1);
+				let dom = once(0..=0).chain(h.keys().map(|&v| v..=v)).collect();
+				let views = h
+					.into_iter()
+					.sorted_by_key(|(c, _)| *c)
+					.map(|(_coef, lits)| {
 						if lits.len() == 1 {
-							(interval, Some(lits[0]))
+							Some(lits[0])
 						} else {
-							let o = new_named_lit!(db, format!("y_{:?}>={:?}", lits, coef));
+							let o = new_named_lit!(db, format!("y_{:?}>={:?}", lits, _coef));
 							for lit in lits {
 								db.add_clause([!lit, o]).unwrap();
 							}
-							(interval, Some(o))
+							Some(o)
 						}
 					})
-					.collect::<IntervalMap<_, _>>();
-				vec![IntVarEnc::Ord(IntVarOrd::from_views(db, dom, lbl))]
+					.collect();
+
+				vec![IntVarEnc::Ord(IntVarOrd::from_views(db, dom, views, lbl))]
 			}
 			// Leaves built from Ic/Dom groups are guaranteed to have unique values
 			Part::Ic(terms) => {
 				let mut acc = 0; // running sum
-				let dom = once(&(terms[0].0, PosCoeff::new(0)))
-					.chain(terms.iter())
-					.map(|&(lit, coef)| {
+				let dom = once(0..=0)
+					.chain(terms.iter().map(|&(_, coef)| {
 						acc += *coef;
-						debug_assert!(acc <= *ub);
-						(acc, lit)
-					})
-					.tuple_windows()
-					.map(|((prev, _), (coef, lit))| ((prev + 1)..(coef + 1), Some(lit)))
-					.collect::<IntervalMap<_, _>>();
-				vec![IntVarEnc::Ord(IntVarOrd::from_views(db, dom, lbl))]
+						acc..=acc
+					}))
+					.collect();
+				let views = terms.iter().map(|&(lit, _)| Some(lit)).collect();
+				vec![IntVarEnc::Ord(IntVarOrd::from_views(db, dom, views, lbl))]
 			}
 			Part::Dom(terms, l, u) => {
 				// TODO account for bounds (or even better, create IntVarBin)
@@ -749,10 +769,11 @@ impl IntVarEnc {
 					terms
 						.iter()
 						.enumerate()
-						.map(|(i, (lit, coef))| {
+						.map(|(i, &(lit, coef))| {
 							IntVarEnc::Ord(IntVarOrd::from_views(
 								db,
-								interval_map! { 1..(**coef+1) => Some(*lit) },
+								RangeList::from_iter([0..=0, *coef..=*coef]),
+								vec![Some(lit)],
 								format!("{lbl}^{i}"),
 							))
 						})
@@ -774,29 +795,18 @@ impl IntVarEnc {
 	}
 
 	/// Returns a clause constraining `x>=v`, which is None if true and empty if false
-	pub(crate) fn geq(&self, v: Range<Coeff>) -> Vec<Vec<Lit>> {
+	pub(crate) fn geq(&self, v: Coeff) -> Formula<BoolVal> {
 		match self {
 			IntVarEnc::Ord(o) => o.geq(v),
 			IntVarEnc::Bin(b) => b.geq(v),
-			IntVarEnc::Const(c) => {
-				let v = v.end - 1;
-				if v <= *c {
-					vec![]
-				} else {
-					vec![vec![]]
-				}
-			}
+			&IntVarEnc::Const(c) => Formula::Atom(BoolVal::Const(v <= c)),
 		}
 	}
 
-	pub(crate) fn geqs(&self) -> Vec<(Range<Coeff>, Vec<Vec<Lit>>)> {
+	pub(crate) fn geqs(&self) -> Vec<(Coeff, Formula<BoolVal>)> {
 		match self {
 			IntVarEnc::Ord(o) => o.geqs(),
-			x => x
-				.dom()
-				.into_iter(..)
-				.map(|c| (c.clone(), x.geq(c)))
-				.collect(),
+			x => x.dom().iter().flatten().map(|c| (c, x.geq(c))).collect(),
 		}
 	}
 
@@ -810,29 +820,18 @@ impl IntVarEnc {
 	}
 
 	/// Returns cnf constraining `x<=v`, which is empty if true and contains empty if false
-	pub(crate) fn leq(&self, v: Range<Coeff>) -> Vec<Vec<Lit>> {
+	pub(crate) fn leq(&self, v: Coeff) -> Formula<BoolVal> {
 		match self {
 			IntVarEnc::Ord(o) => o.leq(v),
 			IntVarEnc::Bin(b) => b.leq(v),
-			IntVarEnc::Const(c) => {
-				let v = v.start + 1; // [x<=v] = [x < v+1]
-				if v <= *c {
-					vec![vec![]]
-				} else {
-					vec![]
-				}
-			}
+			&IntVarEnc::Const(c) => Formula::Atom(BoolVal::Const(v >= c)),
 		}
 	}
 
-	pub(crate) fn leqs(&self) -> Vec<(Range<Coeff>, Vec<Vec<Lit>>)> {
+	pub(crate) fn leqs(&self) -> Vec<(Coeff, Formula<BoolVal>)> {
 		match self {
 			IntVarEnc::Ord(o) => o.leqs(),
-			x => x
-				.dom()
-				.into_iter(..)
-				.map(|c| (c.clone(), x.leq(c)))
-				.collect(),
+			x => x.dom().iter().flatten().map(|c| (c, x.leq(c))).collect(),
 		}
 	}
 
@@ -881,7 +880,7 @@ impl From<IntVarOrd> for IntVarEnc {
 impl IntVarOrd {
 	pub(crate) fn consistency(&self) -> ImplicationChainConstraint {
 		ImplicationChainConstraint {
-			lits: self.xs.values(..).cloned().collect_vec(),
+			lits: self.xs.clone(),
 		}
 	}
 
@@ -890,19 +889,28 @@ impl IntVarOrd {
 	}
 
 	pub(crate) fn div(&self, c: Coeff) -> IntVarEnc {
-		assert!(c == 2, "Can only divide IntVarOrd by 2");
-		let xs: IntervalMap<_, _> = self
-			.xs
-			.iter(..)
-			.filter(|(c, _)| (c.end - 1) % 2 == 0)
-			.map(|(c, l)| (((c.end - 1) / (1 + 1)), *l))
-			.map(|(c, l)| (c..(c + 1), l))
+		assert_eq!(c, 2, "Can only divide IntVarOrd by 2");
+		let mut last = self.lb() / c;
+		let mut xs = Vec::new();
+		for (d, &l) in self.dom().iter().flatten().skip(1).zip_eq(&self.xs) {
+			let nd = d / c;
+			if nd == last {
+				continue;
+			}
+			last = nd;
+			xs.push(l);
+		}
+		let dom = self
+			.dom()
+			.iter()
+			.map(|r| r.start() / c..=r.end() / 2)
 			.collect();
 
 		if xs.is_empty() {
 			IntVarEnc::Const(self.lb() / c)
 		} else {
 			IntVarOrd {
+				dom,
 				xs,
 				lbl: self.lbl.clone(),
 			}
@@ -910,111 +918,101 @@ impl IntVarOrd {
 		}
 	}
 
-	pub(crate) fn dom(&self) -> IntervalSet<Coeff> {
-		once(self.lb()..(self.lb() + 1))
-			.chain(self.xs.intervals(..))
-			.collect()
+	pub(crate) fn dom(&self) -> RangeList<Coeff> {
+		self.dom.clone()
 	}
+
 	pub(crate) fn from_bounds<DB: ClauseDatabase + ?Sized>(
 		db: &mut DB,
 		lb: Coeff,
 		ub: Coeff,
 		lbl: String,
 	) -> Self {
-		Self::from_dom(db, (lb..=ub).collect_vec().as_slice(), lbl)
+		Self::from_dom(db, (lb..=ub).into(), lbl)
 	}
 
 	pub(crate) fn from_dom<DB: ClauseDatabase + ?Sized>(
 		db: &mut DB,
-		dom: &[Coeff],
+		dom: RangeList<Coeff>,
 		lbl: String,
 	) -> Self {
-		Self::from_syms(
-			db,
-			dom.iter()
-				.tuple_windows()
-				.map(|(a, b)| (a + 1)..(b + 1))
-				.collect(),
-			lbl,
-		)
-	}
-
-	pub(crate) fn from_syms<DB: ClauseDatabase + ?Sized>(
-		db: &mut DB,
-		syms: IntervalSet<Coeff>,
-		lbl: String,
-	) -> Self {
-		Self::from_views(db, syms.into_iter(..).map(|c| (c, None)).collect(), lbl)
+		let card = dom.card().unwrap();
+		Self::from_views(db, dom, vec![None; card - 1], lbl)
 	}
 
 	pub(crate) fn from_views<DB: ClauseDatabase + ?Sized>(
 		db: &mut DB,
-		views: IntervalMap<Coeff, Option<Lit>>,
+		dom: RangeList<Coeff>,
+		views: Vec<Option<Lit>>,
 		lbl: String,
 	) -> Self {
-		assert!(!views.is_empty());
-		assert!(
-			views
-				.iter(..)
-				.tuple_windows()
-				.all(|(a, b)| a.0.end == b.0.start),
-			"Expecting contiguous domain of intervals but was {views:?}"
-		);
+		assert!(!dom.is_empty());
+		assert_eq!(dom.card().unwrap() - 1, views.len(), "Expecting the same number of views as there are inequalities literals to represent the domain");
 
-		let xs = views
-			.into_iter(..)
-			.map(|(v, lit)| {
+		let mut dom_it = dom.iter().flatten();
+		// No need for a `<=lb` literal, since it would be `true` and thus redundant.
+		let mut _lb = dom_it.next().unwrap();
+
+		let xs = dom_it
+			.zip_eq(views)
+			.map(|(_v, lit)| {
 				#[cfg(any(feature = "tracing", test))]
-				let lbl = format!("{lbl}>={}..{}", v.start, v.end - 1);
-				(v, lit.unwrap_or_else(|| new_named_lit!(db, lbl)))
+				let lbl = format!("{lbl}>={}", _v);
+				lit.unwrap_or_else(|| new_named_lit!(db, lbl))
 			})
-			.collect::<IntervalMap<_, _>>();
-		Self { xs, lbl }
+			.collect();
+
+		Self { dom, xs, lbl }
 	}
 
-	pub(crate) fn geq(&self, v: Range<Coeff>) -> Vec<Vec<Lit>> {
-		let v = v.end - 1;
-		if v <= self.lb() {
-			vec![]
+	pub(crate) fn geq(&self, v: Coeff) -> Formula<BoolVal> {
+		Formula::Atom(if v <= self.lb() {
+			BoolVal::Const(true)
 		} else if v > self.ub() {
-			vec![vec![]]
+			BoolVal::Const(false)
 		} else {
-			match self.xs.overlap(v).collect_vec()[..] {
-				[(_, x)] => vec![vec![*x]],
-				_ => panic!("No or multiples literals at {v:?} for var {self:?}"),
-			}
-		}
+			let pos = self.dom.first_position_bound(&Bound::Included(v)).unwrap() - 1;
+			BoolVal::Lit(self.xs[pos])
+		})
 	}
 
-	pub(crate) fn geqs(&self) -> Vec<(Range<Coeff>, Vec<Vec<Lit>>)> {
-		once((self.lb()..(self.lb() + 1), vec![]))
-			.chain(self.xs.iter(..).map(|(v, x)| (v, vec![vec![*x]])))
+	pub(crate) fn geqs(&self) -> Vec<(Coeff, Formula<BoolVal>)> {
+		self.dom()
+			.iter()
+			.flatten()
+			.zip_eq(
+				once(Formula::Atom(BoolVal::Const(true)))
+					.chain(self.xs.iter().map(|&l| Formula::Atom(BoolVal::Lit(l)))),
+			)
 			.collect()
 	}
 
 	pub(crate) fn lb(&self) -> Coeff {
-		self.xs.range().unwrap().start - 1
+		*self.dom.lower_bound().unwrap()
 	}
 
-	pub(crate) fn leq(&self, v: Range<Coeff>) -> Vec<Vec<Lit>> {
-		let v = v.start + 1; // [x<=v] = [x < v+1]
-		if v <= self.lb() {
-			vec![vec![]]
+	pub(crate) fn leq(&self, v: Coeff) -> Formula<BoolVal> {
+		let v = v + 1; // [x<=v] = [x < v+1]
+		Formula::Atom(if v <= self.lb() {
+			BoolVal::Const(false)
 		} else if v > self.ub() {
-			vec![]
+			BoolVal::Const(true)
 		} else {
-			match self.xs.overlap(v).collect_vec()[..] {
-				[(_, &x)] => vec![vec![!x]],
-				_ => panic!("No or multiples literals at {v:?} for var {self:?}"),
-			}
-		}
+			let pos = self.dom.first_position_bound(&Bound::Included(v)).unwrap() - 1;
+			BoolVal::Lit(!self.xs[pos])
+		})
 	}
 
-	pub(crate) fn leqs(&self) -> Vec<(Range<Coeff>, Vec<Vec<Lit>>)> {
-		self.xs
-			.iter(..)
-			.map(|(v, &x)| ((v.start - 1)..(v.end - 1), vec![vec![!x]]))
-			.chain(once((self.ub()..self.ub() + 1, vec![])))
+	pub(crate) fn leqs(&self) -> Vec<(Coeff, Formula<BoolVal>)> {
+		self.dom()
+			.iter()
+			.flatten()
+			.zip_eq(
+				self.xs
+					.iter()
+					.map(|&l| Formula::Atom(BoolVal::Lit(!l)))
+					.chain(once(Formula::Atom(BoolVal::Const(true)))),
+			)
 			.collect()
 	}
 
@@ -1024,24 +1022,19 @@ impl IntVarOrd {
 	}
 
 	pub(crate) fn ub(&self) -> Coeff {
-		self.xs.range().unwrap().end - 1
+		*self.dom.upper_bound().unwrap()
 	}
 }
 
 impl Display for IntVarOrd {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(
-			f,
-			"{}:O ∈ {}",
-			self.lbl,
-			display_dom(&self.dom().iter(..).map(|d| d.end - 1).collect())
-		)
+		write!(f, "{}:O ∈ {}", self.lbl, display_dom(&self.dom()))
 	}
 }
 
 impl Lin {
 	pub(crate) fn lb(&self) -> Coeff {
-		self.xs.iter().map(|(c, x)| x.borrow().lb(c)).sum::<i64>()
+		self.xs.iter().map(|(c, x)| x.borrow().lb(*c)).sum::<i64>()
 	}
 
 	pub(crate) fn propagate(&mut self, consistency: &Consistency) -> Vec<usize> {
@@ -1058,18 +1051,18 @@ impl Lin {
 
 						let id = x.id;
 						let x_ub = if c.is_positive() {
-							*x.dom.last().unwrap()
+							*x.dom.upper_bound().unwrap()
 						} else {
-							*x.dom.first().unwrap()
+							*x.dom.lower_bound().unwrap()
 						};
 
 						// c*d >= x_ub*c + xs_ub := d >= x_ub - xs_ub/c
 						let b = x_ub - (xs_ub / *c);
 
 						if !c.is_negative() {
-							x.ge(&b);
+							x.ge(b);
 						} else {
-							x.le(&b);
+							x.le(b);
 						}
 
 						if x.size() < size {
@@ -1085,9 +1078,9 @@ impl Lin {
 					let mut x = x.borrow_mut();
 					let size = x.size();
 					let x_lb = if c.is_positive() {
-						*x.dom.first().unwrap()
+						*x.dom.lower_bound().unwrap()
 					} else {
-						*x.dom.last().unwrap()
+						*x.dom.upper_bound().unwrap()
 					};
 
 					let id = x.id;
@@ -1097,9 +1090,9 @@ impl Lin {
 					let b = x_lb - (rs_lb / *c);
 
 					if c.is_negative() {
-						x.ge(&b);
+						x.ge(b);
 					} else {
-						x.le(&b);
+						x.le(b);
 					}
 
 					if x.size() < size {
@@ -1119,31 +1112,39 @@ impl Lin {
 				loop {
 					let mut fixpoint = true;
 					for (i, (c_i, x_i)) in self.xs.iter().enumerate() {
-						let id = x_i.borrow().id;
-						x_i.borrow_mut().dom.retain(|d_i| {
-							if self
-								.xs
-								.iter()
-								.enumerate()
-								.filter(|&(j, (_c_j, _x_j))| (i != j))
-								.map(|(_j, (c_j, x_j))| {
-									x_j.borrow()
-										.dom
-										.iter()
-										.map(|d_j_k| *c_j * *d_j_k)
-										.collect_vec()
-								})
-								.multi_cartesian_product()
-								.any(|rs| *c_i * *d_i + rs.into_iter().sum::<i64>() == 0)
-							{
-								true
-							} else {
-								fixpoint = false;
-								changed.push(id);
-								false
-							}
-						});
-						assert!(x_i.borrow().size() > 0);
+						let mut x_i = x_i.borrow_mut();
+						let id = x_i.id;
+						x_i.dom = x_i
+							.dom
+							.iter()
+							.flatten()
+							.filter(|d_i| {
+								if self
+									.xs
+									.iter()
+									.enumerate()
+									.filter(|&(j, _)| (i != j))
+									.map(|(_, (c_j, x_j))| {
+										x_j.borrow()
+											.dom
+											.iter()
+											.flatten()
+											.map(|d_j_k| *c_j * d_j_k)
+											.collect_vec()
+									})
+									.multi_cartesian_product()
+									.any(|rs| *c_i * *d_i + rs.into_iter().sum::<i64>() == 0)
+								{
+									true
+								} else {
+									fixpoint = false;
+									changed.push(id);
+									false
+								}
+							})
+							.map(|v| v..=v)
+							.collect();
+						assert!(x_i.size() > 0);
 					}
 
 					if fixpoint {
@@ -1166,7 +1167,7 @@ impl Lin {
 	}
 
 	pub(crate) fn ub(&self) -> Coeff {
-		self.xs.iter().map(|(c, x)| x.borrow().ub(c)).sum::<i64>()
+		self.xs.iter().map(|(c, x)| x.borrow().ub(*c)).sum::<i64>()
 	}
 }
 
@@ -1225,13 +1226,14 @@ impl From<&IntVarEnc> for BoolLinExp {
 impl From<&IntVarOrd> for BoolLinExp {
 	fn from(value: &IntVarOrd) -> Self {
 		let mut acc = value.lb();
+		let mut dom_it = value.dom.iter().flatten();
+		let _ = dom_it.next();
 		BoolLinExp::default()
 			.add_chain(
-				&value
-					.xs
-					.iter(..)
+				&dom_it
+					.zip_eq(&value.xs)
 					.map(|(iv, lit)| {
-						let v = iv.end - 1 - acc;
+						let v = iv - acc;
 						acc += v;
 						(*lit, v)
 					})
@@ -1243,12 +1245,12 @@ impl From<&IntVarOrd> for BoolLinExp {
 
 impl Model {
 	pub(crate) fn add_int_var_enc(&mut self, x: IntVarEnc) -> IntVar {
-		let var = self.new_var(x.dom().iter(..).map(|d| d.end - 1).collect(), false);
+		let var = self.new_var(x.dom(), false);
 		let _ = self.vars.insert(var.id, x);
 		var
 	}
 
-	pub(crate) fn encode<DB: ClauseDatabase + ?Sized>(
+	pub(crate) fn encode<DB: ClauseDatabase + AsDynClauseDatabase>(
 		&mut self,
 		db: &mut DB,
 		cutoff: Option<Coeff>,
@@ -1283,10 +1285,10 @@ impl Model {
 	}
 
 	pub(crate) fn new_constant(&mut self, c: Coeff) -> IntVar {
-		self.new_var(BTreeSet::from([c]), false)
+		self.new_var((c..=c).into(), false)
 	}
 
-	pub(crate) fn new_var(&mut self, dom: BTreeSet<Coeff>, add_consistency: bool) -> IntVar {
+	pub(crate) fn new_var(&mut self, dom: RangeList<Coeff>, add_consistency: bool) -> IntVar {
 		self.var_ids += 1;
 		IntVar {
 			id: self.var_ids,
@@ -1382,7 +1384,7 @@ impl Display for TernLeConstraint<'_> {
 	}
 }
 
-impl<DB: ClauseDatabase + ?Sized> Encoder<DB, TernLeConstraint<'_>> for TernLeEncoder {
+impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, TernLeConstraint<'_>> for TernLeEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "tern_le_encoder", skip_all, fields(constraint = format!("{} + {} {} {}", tern.x, tern.y, tern.cmp, tern.z)))
@@ -1393,17 +1395,35 @@ impl<DB: ClauseDatabase + ?Sized> Encoder<DB, TernLeConstraint<'_>> for TernLeEn
 			const PRINT_TESTCASES: bool = false;
 			if PRINT_TESTCASES {
 				println!(" // {tern}");
-				let x = tern.x.dom().iter(..).map(|iv| iv.end - 1).collect_vec();
-				let y = tern.y.dom().iter(..).map(|iv| iv.end - 1).collect_vec();
-				let z = tern.z.dom().iter(..).map(|iv| iv.end - 1).collect_vec();
+				let x = tern
+					.x
+					.dom()
+					.iter()
+					.flatten()
+					.map(|v| v.to_string())
+					.collect_vec();
+				let y = tern
+					.y
+					.dom()
+					.iter()
+					.flatten()
+					.map(|v| v.to_string())
+					.collect_vec();
+				let z = tern
+					.z
+					.dom()
+					.iter()
+					.flatten()
+					.map(|v| v.to_string())
+					.collect_vec();
 				println!(
 					"mod _test_{}_{}_{} {{\n\ttest_int_lin!($encoder, &[{}], &[{}], $cmp, &[{}]);\n}}\n",
-					x.iter().join(""),
-					y.iter().join(""),
-					z.iter().join(""),
-					x.iter().join(", "),
-					y.iter().join(", "),
-					z.iter().join(", "),
+					x.clone().join(""),
+					y.clone().join(""),
+					z.clone().join(""),
+					x.join(", "),
+					y.join(", "),
+					z.join(", "),
 				);
 			}
 		}
@@ -1562,24 +1582,19 @@ impl<DB: ClauseDatabase + ?Sized> Encoder<DB, TernLeConstraint<'_>> for TernLeEn
 				// x + c <= z == z-c >= x == /\ (z'<=a -> x<=a)
 				for (c_a, z_leq_c_a) in z.leqs() {
 					// TODO alt; just propagate by adding lex constraint
-					let c_a = if z_leq_c_a.is_empty() {
-						c_a.start..(x.ub() + 1)
+					let c_a = if z_leq_c_a == Formula::Atom(BoolVal::Const(true)) {
+						x.ub() + 1
 					} else {
 						c_a
 					};
 
-					let x_leq_c_a = x_bin.leq(c_a.clone());
-					add_clauses_for(db, vec![negate_cnf(z_leq_c_a.clone()), x_leq_c_a])?;
+					let x_leq_c_a = x_bin.leq(c_a);
+					TseitinEncoder.encode(db, &Formula::Or(vec![!z_leq_c_a, x_leq_c_a]))?;
 				}
 				if cmp == &LimitComp::Equal {
 					for (c_a, z_geq_c_a) in z.geqs() {
-						let c_a = if z_geq_c_a.is_empty() {
-							x.lb()..c_a.end
-						} else {
-							c_a
-						};
-						let x_geq_c_a = x_bin.geq(c_a.clone());
-						add_clauses_for(db, vec![negate_cnf(z_geq_c_a.clone()), x_geq_c_a])?;
+						let x_geq_c_a = x_bin.geq(c_a);
+						TseitinEncoder.encode(db, &Formula::Or(vec![!z_geq_c_a, x_geq_c_a]))?;
 					}
 				}
 				Ok(())
@@ -1588,19 +1603,11 @@ impl<DB: ClauseDatabase + ?Sized> Encoder<DB, TernLeConstraint<'_>> for TernLeEn
 				// couple or constrain x:E + y:E <= z:E
 				for (c_a, x_geq_c_a) in x.geqs() {
 					for (c_b, y_geq_c_b) in y.geqs() {
-						// TODO is the max actually correct/good?
-						let c_c =
-							(max(c_a.start, c_b.start))..(((c_a.end - 1) + (c_b.end - 1)) + 1);
+						let z_geq_c_c = z.geq(c_a + c_b);
 
-						let z_geq_c_c = z.geq(c_c.clone());
-
-						add_clauses_for(
+						TseitinEncoder.encode(
 							db,
-							vec![
-								negate_cnf(x_geq_c_a.clone()),
-								negate_cnf(y_geq_c_b),
-								z_geq_c_c,
-							],
+							&Formula::Or(vec![!x_geq_c_a.clone(), !y_geq_c_b, z_geq_c_c]),
 						)?;
 					}
 				}
@@ -1609,17 +1616,11 @@ impl<DB: ClauseDatabase + ?Sized> Encoder<DB, TernLeConstraint<'_>> for TernLeEn
 				if cmp == &LimitComp::Equal {
 					for (c_a, x_leq_c_a) in x.leqs() {
 						for (c_b, y_leq_c_b) in y.leqs() {
-							let c_c = (c_a.start + c_b.start)..(c_a.end - 1 + c_b.end - 1) + 1;
+							let z_leq_c_c = z.leq(c_a + c_b);
 
-							let z_leq_c_c = z.leq(c_c.clone());
-
-							add_clauses_for(
+							TseitinEncoder.encode(
 								db,
-								vec![
-									negate_cnf(x_leq_c_a.clone()),
-									negate_cnf(y_leq_c_b),
-									z_leq_c_c,
-								],
+								&Formula::Or(vec![!x_leq_c_a.clone(), !y_leq_c_b, z_leq_c_c]),
 							)?;
 						}
 					}
@@ -1634,14 +1635,15 @@ impl<DB: ClauseDatabase + ?Sized> Encoder<DB, TernLeConstraint<'_>> for TernLeEn
 pub(crate) mod tests {
 	use std::num::NonZeroI32;
 
-	use iset::{interval_set, IntervalSet};
+	use rangelist::RangeList;
 	use traced_test::test;
 
 	use crate::{
 		bool_linear::{BoolLinExp, LimitComp},
 		helpers::tests::{assert_solutions, expect_file, make_valuation},
 		integer::{IntVarBin, IntVarEnc, IntVarOrd, TernLeConstraint, TernLeEncoder},
-		ClauseDatabase, Cnf, Coeff, Encoder, Lit, Var, VarRange,
+		propositional_logic::Formula,
+		AsDynClauseDatabase, BoolVal, ClauseDatabase, Cnf, Coeff, Encoder, Lit, Var, VarRange,
 	};
 
 	#[test]
@@ -1827,11 +1829,11 @@ pub(crate) mod tests {
 		let c = IntVarEnc::Const(42);
 		assert_eq!(c.lb(), 42);
 		assert_eq!(c.ub(), 42);
-		assert_eq!(c.geq(6..7), Vec::<Vec<_>>::new());
-		assert_eq!(c.geq(45..46), vec![vec![]]);
+		assert_eq!(c.geq(6), Formula::Atom(BoolVal::Const(true)));
+		assert_eq!(c.geq(45), Formula::Atom(BoolVal::Const(false)));
 	}
 
-	fn get_bin_x<DB: ClauseDatabase + ?Sized>(
+	fn get_bin_x<DB: ClauseDatabase + AsDynClauseDatabase>(
 		db: &mut DB,
 		lb: Coeff,
 		ub: Coeff,
@@ -1847,11 +1849,11 @@ pub(crate) mod tests {
 
 	fn get_ord_x<DB: ClauseDatabase + ?Sized>(
 		db: &mut DB,
-		dom: IntervalSet<Coeff>,
+		dom: RangeList<Coeff>,
 		consistent: bool,
 		lbl: String,
 	) -> IntVarEnc {
-		let x = IntVarOrd::from_syms(db, dom, lbl);
+		let x = IntVarOrd::from_dom(db, dom, lbl);
 		if consistent {
 			x.consistent(db).unwrap();
 		}
@@ -1863,7 +1865,7 @@ pub(crate) mod tests {
 		let mut cnf = Cnf::default();
 		let x = get_ord_x(
 			&mut cnf,
-			interval_set!(3..5, 5..7, 7..11),
+			RangeList::from_iter([2..=2, 4..=4, 6..=6, 10..=10]),
 			true,
 			"x".to_owned(),
 		);
@@ -1875,8 +1877,14 @@ pub(crate) mod tests {
 		assert_eq!(x.lits(), 3);
 		assert_eq!(x.lb(), 2);
 		assert_eq!(x.ub(), 10);
-		assert_eq!(x.geq(6..7), vec![vec![Lit(NonZeroI32::new(2).unwrap())]]);
-		assert_eq!(x.geq(4..7), vec![vec![Lit(NonZeroI32::new(2).unwrap())]]);
+		assert_eq!(
+			x.geq(6),
+			Formula::Atom(BoolVal::Lit(Lit(NonZeroI32::new(2).unwrap())))
+		);
+		assert_eq!(
+			x.geq(5),
+			Formula::Atom(BoolVal::Lit(Lit(NonZeroI32::new(2).unwrap())))
+		);
 
 		let x_lin = BoolLinExp::from(&x);
 		assert!(x_lin.value(&make_valuation(&[1, -2, 3])).is_err());
@@ -1904,7 +1912,12 @@ pub(crate) mod tests {
 	fn ord_le_bin_test() {
 		let mut cnf = Cnf::default();
 		let (x, y, z) = (
-			get_ord_x(&mut cnf, interval_set!(1..2, 2..7), true, "x".to_owned()),
+			get_ord_x(
+				&mut cnf,
+				RangeList::from_iter([0..=0, 1..=1, 6..=6]),
+				true,
+				"x".to_owned(),
+			),
 			// TODO 'gapped' in interval_set:
 			// get_ord_x(&mut db, interval_set!(1..2, 5..7), true, "x".to_string()),
 			IntVarEnc::Const(0),
@@ -1937,8 +1950,18 @@ pub(crate) mod tests {
 	fn ord_plus_ord_le_bin_test() {
 		let mut cnf = Cnf::default();
 		let (x, y, z) = (
-			get_ord_x(&mut cnf, interval_set!(1..3), true, "x".to_owned()),
-			get_ord_x(&mut cnf, interval_set!(1..4), true, "y".to_owned()),
+			get_ord_x(
+				&mut cnf,
+				RangeList::from_iter([0..=0, 2..=2]),
+				true,
+				"x".to_owned(),
+			),
+			get_ord_x(
+				&mut cnf,
+				RangeList::from_iter([0..=0, 3..=3]),
+				true,
+				"y".to_owned(),
+			),
 			get_bin_x(&mut cnf, 0, 6, true, "z".to_owned()),
 		);
 		let vars = VarRange::new(
@@ -1968,9 +1991,24 @@ pub(crate) mod tests {
 	fn ord_plus_ord_le_ord_test() {
 		let mut cnf = Cnf::default();
 		let (x, y, z) = (
-			get_ord_x(&mut cnf, interval_set!(1..2, 2..7), true, "x".to_owned()),
-			get_ord_x(&mut cnf, interval_set!(2..3, 3..5), true, "y".to_owned()),
-			get_ord_x(&mut cnf, interval_set!(0..4, 4..11), true, "z".to_owned()),
+			get_ord_x(
+				&mut cnf,
+				RangeList::from_iter([0..=0, 1..=1, 6..=6]),
+				true,
+				"x".to_owned(),
+			),
+			get_ord_x(
+				&mut cnf,
+				RangeList::from_iter([1..=1, 2..=2, 4..=4]),
+				true,
+				"y".to_owned(),
+			),
+			get_ord_x(
+				&mut cnf,
+				RangeList::from_iter([-1..=-1, 3..=3, 10..=10]),
+				true,
+				"z".to_owned(),
+			),
 		);
 		let vars = VarRange::new(
 			Var(NonZeroI32::new(1).unwrap()),

--- a/crates/pindakaas/src/sorted.rs
+++ b/crates/pindakaas/src/sorted.rs
@@ -1,14 +1,13 @@
-use std::{cmp::min, hash, mem, sync::Mutex};
+use std::{cmp::min, hash, iter::once, mem, sync::Mutex};
 
-use iset::interval_map;
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
 
 use crate::{
 	bool_linear::{BoolLinExp, LimitComp},
-	helpers::{add_clauses_for, negate_cnf},
 	integer::{IntVarEnc, IntVarOrd, TernLeConstraint, TernLeEncoder},
-	Checker, ClauseDatabase, ClauseDatabaseTools, Coeff, Encoder, Lit, Result, Unsatisfiable,
+	propositional_logic::{Formula, TseitinEncoder},
+	AsDynClauseDatabase, Checker, ClauseDatabase, Coeff, Encoder, Lit, Result, Unsatisfiable,
 	Valuation,
 };
 
@@ -77,7 +76,7 @@ impl Checker for Sorted<'_> {
 }
 
 impl SortedEncoder {
-	fn comp<DB: ClauseDatabase + ?Sized>(
+	fn comp<DB: ClauseDatabase + AsDynClauseDatabase>(
 		&self,
 		db: &mut DB,
 		x: &IntVarEnc,
@@ -87,35 +86,20 @@ impl SortedEncoder {
 		c: Coeff,
 	) -> Result {
 		let cmp = self.overwrite_recursive_cmp.as_ref().unwrap_or(cmp);
-		let to_iv = |c: Coeff| c..(c + 1);
-		let empty_clause: Vec<Vec<Lit>> = vec![Vec::new()];
 		let c1 = c;
 		let c2 = c + 1;
-		let x = x.geq(to_iv(c1)); // c
-		let y = y.geq(to_iv(c2)); // c+1
-		let z1 = z.geq(to_iv(c1 + c1)); // 2c
-		let z2 = z.geq(to_iv(c1 + c2)); // 2c+1
+		let x = x.geq(c1); // c
+		let y = y.geq(c2); // c+1
+		let z1 = z.geq(c1 + c1); // 2c
+		let z2 = z.geq(c1 + c2); // 2c+1
 
-		add_clauses_for(
-			db,
-			vec![negate_cnf(x.clone()), empty_clause.clone(), z1.clone()],
-		)?;
-		add_clauses_for(
-			db,
-			vec![negate_cnf(y.clone()), empty_clause.clone(), z1.clone()],
-		)?;
-		add_clauses_for(
-			db,
-			vec![negate_cnf(x.clone()), negate_cnf(y.clone()), z2.clone()],
-		)?;
-
+		TseitinEncoder.encode(db, &Formula::Or(vec![!x.clone(), z1.clone()]))?;
+		TseitinEncoder.encode(db, &Formula::Or(vec![!y.clone(), z1.clone()]))?;
+		TseitinEncoder.encode(db, &Formula::Or(vec![!x.clone(), !y.clone(), z2.clone()]))?;
 		if cmp == &LimitComp::Equal {
-			add_clauses_for(
-				db,
-				vec![x.clone(), empty_clause.clone(), negate_cnf(z2.clone())],
-			)?;
-			add_clauses_for(db, vec![y.clone(), empty_clause, negate_cnf(z2)])?;
-			add_clauses_for(db, vec![x, y, negate_cnf(z1)])?;
+			TseitinEncoder.encode(db, &Formula::Or(vec![x.clone(), !z2.clone()]))?;
+			TseitinEncoder.encode(db, &Formula::Or(vec![y.clone(), !z2]))?;
+			TseitinEncoder.encode(db, &Formula::Or(vec![x, y, !z1]))?;
 		}
 		Ok(())
 	}
@@ -127,7 +111,7 @@ impl SortedEncoder {
 		self
 	}
 
-	fn merged<DB: ClauseDatabase + ?Sized>(
+	fn merged<DB: ClauseDatabase + AsDynClauseDatabase>(
 		&self,
 		db: &mut DB,
 		x1: &IntVarEnc,
@@ -210,7 +194,7 @@ impl SortedEncoder {
 		}
 	}
 
-	fn next_int_var<DB: ClauseDatabase + ?Sized>(
+	fn next_int_var<DB: ClauseDatabase + AsDynClauseDatabase>(
 		&self,
 		db: &mut DB,
 		ub: Coeff,
@@ -229,7 +213,7 @@ impl SortedEncoder {
 	}
 
 	/// The sorted/merged base case of x1{0,1}+x2{0,1}<=y{0,1,2}
-	fn smerge<DB: ClauseDatabase + ?Sized>(
+	fn smerge<DB: ClauseDatabase + AsDynClauseDatabase>(
 		&self,
 		db: &mut DB,
 		x1: &IntVarEnc,
@@ -255,7 +239,7 @@ impl SortedEncoder {
 		self.comp(db, x1, &x2, cmp, &y, 1)
 	}
 
-	fn sort<DB: ClauseDatabase + ?Sized>(
+	fn sort<DB: ClauseDatabase + AsDynClauseDatabase>(
 		&self,
 		db: &mut DB,
 		xs: &[IntVarEnc],
@@ -275,7 +259,7 @@ impl SortedEncoder {
 		}
 	}
 
-	fn sorted<DB: ClauseDatabase + ?Sized>(
+	fn sorted<DB: ClauseDatabase + AsDynClauseDatabase>(
 		&self,
 		db: &mut DB,
 		xs: &[IntVarEnc],
@@ -301,14 +285,15 @@ impl SortedEncoder {
 		if direct {
 			return (1..=m + 1).try_for_each(|k| {
 				xs.iter()
-					.map(|x| x.geq(1..2)[0][0])
+					.map(|x| x.geq(1))
 					.combinations(k as usize)
 					.try_for_each(|lits| {
-						db.add_clause(
-							lits.into_iter()
-								.map(|lit| !lit)
-								.chain(y.geq(k..(k + 1))[0].iter().cloned()),
-						)
+						let lits = lits
+							.into_iter()
+							.map(|lit| !lit)
+							.chain(once(y.geq(k)))
+							.collect();
+						TseitinEncoder.encode(db, &Formula::Or(lits))
 					})
 			});
 		}
@@ -403,7 +388,7 @@ impl Default for SortedEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase + ?Sized> Encoder<DB, Sorted<'_>> for SortedEncoder {
+impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, Sorted<'_>> for SortedEncoder {
 	fn encode(&self, db: &mut DB, sorted: &Sorted) -> Result {
 		let xs = sorted
 			.xs
@@ -411,8 +396,7 @@ impl<DB: ClauseDatabase + ?Sized> Encoder<DB, Sorted<'_>> for SortedEncoder {
 			.map(|x| Some(*x))
 			.enumerate()
 			.map(|(i, x)| {
-				IntVarOrd::from_views(db, interval_map! { 1..2 => x }, format!("x_{}", i + 1))
-					.into()
+				IntVarOrd::from_views(db, (0..=1).into(), vec![x], format!("x_{}", i + 1)).into()
 			})
 			.collect_vec();
 
@@ -424,7 +408,7 @@ impl<DB: ClauseDatabase + ?Sized> Encoder<DB, Sorted<'_>> for SortedEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase + ?Sized> Encoder<DB, TernLeConstraint<'_>> for SortedEncoder {
+impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, TernLeConstraint<'_>> for SortedEncoder {
 	fn encode(&self, db: &mut DB, tern: &TernLeConstraint) -> Result {
 		let TernLeConstraint { x, y, cmp, z } = tern;
 		if tern.is_fixed()? {


### PR DESCRIPTION
To remove the dependency, the domain representation in IntVarOrd has
been changed to use a `RangeList` for the domain itself and a `Vec` to
store the literals they represent.

The `bdd` function that tracked a node mapping using an interval map
has been changed to use a sorted vector and binary search.

For convenience in making the changes, the `geq` and `leq` method have
been changed to take only a single integer value and return a `Formula`
object that can then be further combined and encoded.
