### PR TITLE
Python CNF Enhancements

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "crates/pyndakaas" # codecov has not been setup for Python testing

--- a/crates/pindakaas/src/lib.rs
+++ b/crates/pindakaas/src/lib.rs
@@ -606,8 +606,13 @@ impl Cnf {
 	}
 
 	/// Returns the number of variables in the formula.
-	pub fn variables(&self) -> usize {
+	pub fn num_vars(&self) -> usize {
 		self.nvar.num_emitted_vars()
+	}
+
+	/// Returns the range of variables emitted to be used by this formula.
+	pub fn variables(&self) -> VarRange {
+		self.nvar.emitted_vars()
 	}
 }
 
@@ -631,7 +636,7 @@ impl ClauseDatabase for Cnf {
 
 impl Display for Cnf {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		let num_var = &self.variables();
+		let num_var = &self.num_vars();
 		let num_clauses = self.size.len();
 		writeln!(f, "p cnf {num_var} {num_clauses}")?;
 		let mut start = 0;
@@ -1075,8 +1080,13 @@ impl Wcnf {
 	}
 
 	/// Returns the number of clauses in the formula.
-	pub fn clauses(&self) -> usize {
+	pub fn num_clauses(&self) -> usize {
 		self.cnf.num_clauses()
+	}
+
+	/// Returns the number of variables in the formula.
+	pub fn num_vars(&self) -> usize {
+		self.cnf.num_vars()
 	}
 
 	/// Read a WCNF formula from a file formatted in the (W)DIMACS WCNF format
@@ -1110,8 +1120,8 @@ impl Wcnf {
 		write!(file, "{self}")
 	}
 
-	/// Returns the number of variables in the formula.
-	pub fn variables(&self) -> usize {
+	/// Returns the range of variables emitted to be used by this formula.
+	pub fn variables(&self) -> VarRange {
 		self.cnf.variables()
 	}
 }

--- a/crates/pyndakaas/docs/source/conf.py
+++ b/crates/pyndakaas/docs/source/conf.py
@@ -1,5 +1,6 @@
-import tomllib
 from pathlib import Path
+
+import tomllib
 
 workspace = Path(__file__).parent.parent.parent.parent.parent
 

--- a/crates/pyndakaas/python/pindakaas/encoding.py
+++ b/crates/pyndakaas/python/pindakaas/encoding.py
@@ -6,6 +6,7 @@ from .pindakaas import (
     Encoder,
     Formula,
     Lit,
+    VarRange,
     WCNFInner,
     _wrap_encode_constraint,
 )
@@ -48,9 +49,9 @@ class ClauseDatabase(ABC):
 
     def new_var(self):
         """Add a new variable to the database."""
-        (start, end) = self.new_var_range(1)
-        assert start == end
-        return start
+        r = self.new_var_range(1)
+        assert r.start() == r.end()
+        return r.start()
 
     def new_vars(self, n: int) -> Iterable[Lit]:
         """Add `n` new variables to the database.
@@ -58,11 +59,10 @@ class ClauseDatabase(ABC):
         :param n: The number of new variables
         :return: The new variables returned as literals
         """
-        (start, end) = self.new_var_range(n)
-        return [Lit.from_raw(i) for i in range(int(start), int(end) + 1)]
+        return self.new_var_range(n)
 
     @abstractmethod
-    def new_var_range(self, n: int) -> tuple[Lit, Lit]:
+    def new_var_range(self, n: int) -> VarRange:
         """Add a continuous range of `n` new variables to the database.
 
         :param n: The number of new variables
@@ -92,7 +92,15 @@ class CNF(ClauseDatabase):
         conditions = list(conditions) if conditions is not None else []
         return self._inner.add_encoding(constraint, encoder, conditions)
 
-    def new_var_range(self, n: int) -> tuple[Lit, Lit]:
+    def clauses(self) -> Iterable[list[Lit]]:
+        """
+        Returns an iterable representation of the clauses currently included in the CNF.
+
+        :return: An iterable of lists of literals representing the clauses.
+        """
+        return self._inner.clauses()
+
+    def new_var_range(self, n: int) -> VarRange:
         return self._inner.new_var_range(n)
 
     def to_dimacs(self) -> str:
@@ -102,10 +110,22 @@ class CNF(ClauseDatabase):
         """
         return self._inner.to_dimacs()
 
+    def variables(self) -> Iterable[Lit]:
+        """
+        Returns a iterable representation of the variables currently included in the
+        CNF.
+
+        :return: An iterable of literals representing the variables.
+        """
+        return self._inner.variables()
+
 
 class WCNF(CNF):
     """A representation for Boolean formulas in conjunctive normal form with weighted
     (soft) clauses.
+
+    Note that `WCNF.clauses` only iterates over the hard clauses. Use
+    `WCNF.weighted_clauses` to iterate over all clauses.
     """
 
     _inner: WCNFInner
@@ -120,3 +140,12 @@ class WCNF(CNF):
         :param weight: the weight of the clause
         """
         return self._inner.add_weighted_clause(iter(clause), weight)
+
+    def weighted_clauses(self) -> Iterable[tuple[Optional[int], list[Lit]]]:
+        """
+        Returns an iterable representation of the weighted clauses currently included in
+        the WCNF.
+
+        :return: An iterable of lists of literals representing the clauses.
+        """
+        return self._inner.weighted_clauses()

--- a/crates/pyndakaas/python/pindakaas/encoding.py
+++ b/crates/pyndakaas/python/pindakaas/encoding.py
@@ -1,9 +1,16 @@
 from abc import ABC, abstractmethod
-from typing import Iterable, Optional, TypeAlias
+from typing import Iterable, Optional
 
-from .pindakaas import CNFInner, Encoder, Formula, Lit, WCNFInner
+from .pindakaas import (
+    CNFInner,
+    Encoder,
+    Formula,
+    Lit,
+    WCNFInner,
+    _wrap_encode_constraint,
+)
 
-Constraint: TypeAlias = Formula
+Constraint = Formula
 
 
 class ClauseDatabase(ABC):
@@ -24,7 +31,6 @@ class ClauseDatabase(ABC):
         """
         ...
 
-    @abstractmethod
     def add_encoding(
         self,
         constraint: Constraint,
@@ -38,18 +44,30 @@ class ClauseDatabase(ABC):
         :param constraint: The constraint or formula to encode and add to the database
         :raises Unsatisfiable: If the formula has become unsatisfiable
         """
-        ...
+        _wrap_encode_constraint(self, constraint, encoder, conditions)
 
     def new_var(self):
         """Add a new variable to the database."""
-        return self.new_vars(1).__iter__().__next__()
+        (start, end) = self.new_var_range(1)
+        assert start == end
+        return start
 
-    @abstractmethod
     def new_vars(self, n: int) -> Iterable[Lit]:
         """Add `n` new variables to the database.
 
         :param n: The number of new variables
         :return: The new variables returned as literals
+        """
+        (start, end) = self.new_var_range(n)
+        return [Lit.from_raw(i) for i in range(int(start), int(end) + 1)]
+
+    @abstractmethod
+    def new_var_range(self, n: int) -> tuple[Lit, Lit]:
+        """Add a continuous range of `n` new variables to the database.
+
+        :param n: The number of new variables
+        :return: The start and end of the range of the new variables (inclusive), given
+            as literals.
         """
         ...
 
@@ -74,8 +92,8 @@ class CNF(ClauseDatabase):
         conditions = list(conditions) if conditions is not None else []
         return self._inner.add_encoding(constraint, encoder, conditions)
 
-    def new_vars(self, n: int) -> Iterable[Lit]:
-        return self._inner.new_vars(n)
+    def new_var_range(self, n: int) -> tuple[Lit, Lit]:
+        return self._inner.new_var_range(n)
 
     def to_dimacs(self) -> str:
         """Return a textual representation in the DIMACS format.

--- a/crates/pyndakaas/python/pindakaas/solver.py
+++ b/crates/pyndakaas/python/pindakaas/solver.py
@@ -106,8 +106,8 @@ class CaDiCaL(Solver):
         conditions = list(conditions) if conditions is not None else []
         return self._inner.add_encoding(constraint, encoder, conditions)
 
-    def new_vars(self, n: int):
-        return self._inner.new_vars(n)
+    def new_var_range(self, n: int):
+        return self._inner.new_var_range(n)
 
 
 class MapResult(Result):

--- a/crates/pyndakaas/python/tests/test_encoding.py
+++ b/crates/pyndakaas/python/tests/test_encoding.py
@@ -10,6 +10,7 @@ from pindakaas import (
     Lit,
     Unsatisfiable,
 )
+from pindakaas.encoding import VarRange
 
 
 class CustomDB(ClauseDatabase):
@@ -23,10 +24,10 @@ class CustomDB(ClauseDatabase):
     def add_clause(self, clause: Iterable[Lit]):
         self.clauses.append([int(lit) for lit in clause])
 
-    def new_var_range(self, n: int) -> tuple[Lit, Lit]:
+    def new_var_range(self, n: int) -> VarRange:
         start = self.next_var
         self.next_var += n
-        return Lit.from_raw(start), Lit.from_raw(self.next_var - 1)
+        return VarRange(Lit.from_raw(start), Lit.from_raw(self.next_var - 1))
 
 
 def test_unsat():
@@ -38,8 +39,10 @@ def test_unsat():
 def test_cnf():
     f = CNF()
     x, y = f.new_vars(2)
+    assert list(f.variables()) == [x, y]
     f.add_clause([x, y])
     assert f.to_dimacs() == "p cnf 2 1\n1 2 0\n"
+    assert f.clauses() == [[x, y]]
 
 
 def test_encode_bool_lin_unsat():

--- a/crates/pyndakaas/python/tests/test_encoding.py
+++ b/crates/pyndakaas/python/tests/test_encoding.py
@@ -1,36 +1,63 @@
-import pindakaas
+from typing import Iterable
+
 import pytest
+from pindakaas import (
+    CNF,
+    WCNF,
+    ClauseDatabase,
+    Encoder,
+    InvalidEncoder,
+    Lit,
+    Unsatisfiable,
+)
+
+
+class CustomDB(ClauseDatabase):
+    clauses: list[list[int]]
+    next_var: int
+
+    def __init__(self):
+        self.clauses = []
+        self.next_var = 1
+
+    def add_clause(self, clause: Iterable[Lit]):
+        self.clauses.append([int(lit) for lit in clause])
+
+    def new_var_range(self, n: int) -> tuple[Lit, Lit]:
+        start = self.next_var
+        self.next_var += n
+        return Lit.from_raw(start), Lit.from_raw(self.next_var - 1)
 
 
 def test_unsat():
-    f = pindakaas.CNF()
-    with pytest.raises(pindakaas.Unsatisfiable):
+    f = CNF()
+    with pytest.raises(Unsatisfiable):
         f.add_clause([])
 
 
 def test_cnf():
-    f = pindakaas.CNF()
+    f = CNF()
     x, y = f.new_vars(2)
     f.add_clause([x, y])
     assert f.to_dimacs() == "p cnf 2 1\n1 2 0\n"
 
 
 def test_encode_bool_lin_unsat():
-    f = pindakaas.CNF()
+    f = CNF()
     x, y, z = f.new_vars(3)
-    with pytest.raises(pindakaas.Unsatisfiable):
+    with pytest.raises(Unsatisfiable):
         f += x * 3 + y * 2 + z >= 10
 
 
 def test_invalid_encoder():
-    f = pindakaas.CNF()
+    f = CNF()
     x, y, z = f.new_vars(3)
-    with pytest.raises(pindakaas.InvalidEncoder):
-        f.add_encoding(x * 3 + y * 2 + z >= 3, encoder=pindakaas.Encoder.PAIRWISE)
+    with pytest.raises(InvalidEncoder):
+        f.add_encoding(x * 3 + y * 2 + z >= 3, encoder=Encoder.PAIRWISE)
 
 
 def test_encode_bool_lin_default():
-    f = pindakaas.CNF()
+    f = CNF()
     x, y, z = f.new_vars(3)
     f += x * 3 + y * 2 + z >= 3
     x, y, z = f.new_vars(3)
@@ -56,16 +83,16 @@ def test_encode_bool_lin_default():
 
 
 def test_encode_formula():
-    f = pindakaas.CNF()
+    f = CNF()
     x, y, z = f.new_vars(3)
     f += x ^ z
-    f.add_encoding(x == y, pindakaas.Encoder.TSEITIN)
+    f.add_encoding(x == y, Encoder.TSEITIN)
     f.add_encoding(x & y)
     assert f.to_dimacs() == "p cnf 3 6\n1 3 0\n-1 -3 0\n-1 2 0\n1 -2 0\n1 0\n2 0\n"
 
 
 def test_wcnf():
-    f = pindakaas.WCNF()
+    f = WCNF()
     x, y = f.new_vars(2)
     f.add_clause([x, y])
     f.add_weighted_clause([x], 1)
@@ -74,7 +101,24 @@ def test_wcnf():
 
 
 def test_conditions():
-    f = pindakaas.CNF()
+    f = CNF()
     x, y, p = f.new_vars(3)
     f.add_encoding(x ^ y, conditions=[p])
     assert f.to_dimacs() == "p cnf 3 2\n3 1 2 0\n3 -1 -2 0\n"
+
+
+def test_custom_db():
+    f = CustomDB()
+    assert f.new_var() == Lit.from_raw(1)
+    x, y, p = f.new_vars(3)
+    assert [x, y, p] == [
+        Lit.from_raw(2),
+        Lit.from_raw(3),
+        Lit.from_raw(4),
+    ]
+
+    f.add_encoding(x ^ y, conditions=[p])
+    assert f.clauses == [
+        [4, 2, 3],
+        [4, -2, -3],
+    ]

--- a/crates/pyndakaas/python/tests/test_solving.py
+++ b/crates/pyndakaas/python/tests/test_solving.py
@@ -28,4 +28,6 @@ def test_assumptions():
         assert result.value(y) is True
     with slv.solve(assumptions=[x, y]) as result:
         assert result.status == pindakaas.solver.Status.UNSATISFIABLE
-        assert result.failed(x) or result.failed(y), "One or the other variable should have been used to prove UNSAT"
+        assert result.failed(x) or result.failed(y), (
+            "One or the other variable should have been used to prove UNSAT"
+        )

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -66,10 +66,10 @@ mod pindakaas {
 		cardinality::SortingNetworkEncoder,
 		cardinality_one::{BitwiseEncoder, LadderEncoder, PairwiseEncoder},
 		propositional_logic::{Formula as BaseFormula, TseitinEncoder},
-		BoolVal, ClauseDatabase, ClauseDatabaseTools, Cnf, Encoder as _, Lit as BaseLit, VarRange,
-		Wcnf,
+		BoolVal, ClauseDatabase, ClauseDatabaseTools, Cnf, Encoder as _, Lit as BaseLit,
+		VarRange as BaseVarRange, Wcnf,
 	};
-	use pyo3::{prelude::*, types::PyIterator};
+	use pyo3::{exceptions::PyValueError, prelude::*, types::PyIterator};
 
 	#[pymodule_export]
 	use crate::InvalidEncoder;
@@ -170,6 +170,11 @@ mod pindakaas {
 	struct Lit(BaseLit);
 
 	#[pyclass]
+	#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+	/// Representation of a continuous range of variables.
+	struct VarRange(BaseVarRange);
+
+	#[pyclass]
 	#[derive(Clone, Debug, Default)]
 	/// The internal representation of a CNF formula where clauses have optional
 	/// associated weights.
@@ -262,7 +267,7 @@ mod pindakaas {
 				&mut self,
 				clause: &[BaseLit],
 			) -> Result<(), pindakaas::Unsatisfiable> {
-				let clause: Vec<_> = clause.iter().map(|&l| Lit(l)).collect();
+				let clause = clause.iter().map(|&l| Lit(l)).collect_vec();
 				let res = self.0.call_method1("add_clause", (clause,));
 				match res {
 					Err(e) if e.is_instance_of::<Unsatisfiable>(self.0.py()) => {
@@ -275,7 +280,7 @@ mod pindakaas {
 				}
 			}
 
-			fn new_var_range(&mut self, len: usize) -> VarRange {
+			fn new_var_range(&mut self, len: usize) -> BaseVarRange {
 				let tup = self
 					.0
 					.call_method1("new_var_range", (len,))
@@ -283,7 +288,7 @@ mod pindakaas {
 				let (start, end): (Lit, Lit) = tup
 					.extract()
 					.expect("new_var_range did not return a tuple of two literals");
-				VarRange::new(start.0.var(), end.0.var())
+				BaseVarRange::new(start.0.var(), end.0.var())
 			}
 		}
 
@@ -411,18 +416,31 @@ mod pindakaas {
 			encode_constraint_with_conditions(&mut self.0, con, enc, conditions)
 		}
 
+		fn clauses(&self) -> Vec<Vec<Lit>> {
+			// TODO: It would be great if this could be converted to be lazy, but it
+			// seems a little tricky. This should probably be okay for now.
+			self.0
+				.iter()
+				.map(|c| c.iter().map(|&lit| Lit(lit)).collect())
+				.collect()
+		}
+
 		#[new]
 		fn new() -> Self {
 			Self(Default::default())
 		}
 
-		fn new_var_range(&mut self, num_vars: usize) -> (Lit, Lit) {
+		fn new_var_range(&mut self, num_vars: usize) -> VarRange {
 			let range = self.0.new_var_range(num_vars);
-			(Lit(range.start().into()), Lit(range.end().into()))
+			VarRange(range)
 		}
 
 		fn to_dimacs(&self) -> String {
 			self.0.to_string()
+		}
+
+		fn variables(&self) -> VarRange {
+			VarRange(self.0.variables())
 		}
 	}
 
@@ -620,6 +638,39 @@ mod pindakaas {
 	}
 
 	#[pymethods]
+	impl VarRange {
+		fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+			slf
+		}
+
+		fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<Lit> {
+			slf.0.next().map(|lit| Lit(lit.into()))
+		}
+
+		/// Returns the final variable included in the range.
+		fn end(&self) -> Lit {
+			Lit(self.0.end().into())
+		}
+
+		#[new]
+		/// Create a new variable range that includes all variables between `start`
+		/// and `end` (inclusive).
+		fn new(start: Lit, end: Lit) -> PyResult<Self> {
+			if start.is_negated() || end.is_negated() {
+				return Err(PyValueError::new_err(
+					"`start' and `end' must be positive literals (directly representing variables)",
+				));
+			}
+			Ok(Self(BaseVarRange::new(start.0.var(), end.0.var())))
+		}
+
+		/// Returns the first variable included in the range.
+		fn start(&self) -> Lit {
+			Lit(self.0.start().into())
+		}
+	}
+
+	#[pymethods]
 	impl WCNFInner {
 		fn add_clause(&mut self, clause: Bound<'_, PyIterator>) -> Result {
 			let clause: Vec<Lit> = clause
@@ -649,18 +700,41 @@ mod pindakaas {
 			Ok(())
 		}
 
+		fn clauses(&self) -> Vec<Vec<Lit>> {
+			// TODO: It would be great if this could be converted to be lazy, but it
+			// seems a little tricky. This should probably be okay for now.
+			self.0
+				.iter()
+				.filter(|(_, w)| w.is_none())
+				.map(|(c, _)| c.iter().map(|&lit| Lit(lit)).collect_vec())
+				.collect()
+		}
+
 		#[new]
 		fn new() -> Self {
 			Self(Default::default())
 		}
 
-		fn new_var_range(&mut self, num_vars: usize) -> (Lit, Lit) {
+		fn new_var_range(&mut self, num_vars: usize) -> VarRange {
 			let range = self.0.new_var_range(num_vars);
-			(Lit(range.start().into()), Lit(range.end().into()))
+			VarRange(range)
 		}
 
 		fn to_dimacs(&self) -> String {
 			self.0.to_string()
+		}
+
+		fn variables(&self) -> VarRange {
+			VarRange(self.0.variables())
+		}
+
+		fn weighted_clauses(&self) -> Vec<(Option<i64>, Vec<Lit>)> {
+			// TODO: It would be great if this could be converted to be lazy, but it
+			// seems a little tricky. This should probably be okay for now.
+			self.0
+				.iter()
+				.map(|(c, &w)| (w, (c.iter().map(|&lit| Lit(lit)).collect())))
+				.collect()
 		}
 	}
 

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -742,7 +742,6 @@ mod pindakaas {
 	mod solver {
 		use std::{
 			collections::HashMap,
-			sync::Mutex,
 			time::{Duration, SystemTime},
 		};
 
@@ -762,7 +761,7 @@ mod pindakaas {
 		#[pyclass(unsendable)]
 		#[derive(Debug, Default)]
 		/// The internal representation of a instance of the CaDiCaL solver.
-		struct CaDiCaLInner(Mutex<Cadical>);
+		struct CaDiCaLInner(Cadical);
 
 		#[pyclass(eq, eq_int)]
 		#[derive(Clone, Copy, Debug, PartialEq)]
@@ -804,8 +803,7 @@ mod pindakaas {
 					.into_iter()
 					.map(|any| any.and_then(|lit| lit.extract::<Lit>()))
 					.try_collect()?;
-				let mut guard = self.0.lock()?;
-				guard.add_clause(clause.into_iter().map(|lit| lit.0))?;
+				self.0.add_clause(clause.into_iter().map(|lit| lit.0))?;
 				Ok(())
 			}
 
@@ -815,8 +813,7 @@ mod pindakaas {
 				enc: Option<Encoder>,
 				conditions: Vec<Lit>,
 			) -> Result {
-				let mut guard = self.0.lock().unwrap();
-				encode_constraint_with_conditions(&mut *guard, con, enc, conditions)
+				encode_constraint_with_conditions(&mut self.0, con, enc, conditions)
 			}
 
 			#[new]
@@ -825,24 +822,21 @@ mod pindakaas {
 			}
 
 			fn new_var_range(&mut self, num_vars: usize) -> Result<(Lit, Lit)> {
-				let mut guard = self.0.lock()?;
-				let range = guard.new_var_range(num_vars);
+				let range = self.0.new_var_range(num_vars);
 				Ok((Lit(range.start().into()), Lit(range.end().into())))
 			}
 
 			fn set_time_limit(&mut self, limit: Option<Duration>) -> Result {
-				let mut guard = self.0.lock()?;
-				guard.set_terminate_callback(limit.map(dur_term_fn));
+				self.0.set_terminate_callback(limit.map(dur_term_fn));
 				Ok(())
 			}
 
 			fn solve_assuming(
-				&self,
+				&mut self,
 				assumptions: Vec<Lit>,
 			) -> Result<(Status, HashMap<i32, bool>)> {
-				let mut guard = self.0.lock()?;
-				let vars = guard.emitted_vars();
-				let result = guard.solve_assuming(assumptions.iter().map(|&lit| lit.0));
+				let vars = self.0.emitted_vars();
+				let result = self.0.solve_assuming(assumptions.iter().map(|&lit| lit.0));
 				Ok(match result {
 					SolveResult::Satisfied(sol) => (
 						Status::SATISFIED,

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -53,7 +53,10 @@ impl From<ErrWrapper> for PyErr {
 
 #[pymodule]
 mod pindakaas {
-	use std::fmt::{self, Display};
+	use std::{
+		fmt::{self, Display},
+		num::NonZeroI32,
+	};
 
 	use pindakaas::{
 		bool_linear::{
@@ -63,7 +66,8 @@ mod pindakaas {
 		cardinality::SortingNetworkEncoder,
 		cardinality_one::{BitwiseEncoder, LadderEncoder, PairwiseEncoder},
 		propositional_logic::{Formula as BaseFormula, TseitinEncoder},
-		BoolVal, ClauseDatabase, ClauseDatabaseTools, Cnf, Encoder as _, Lit as BaseLit, Wcnf,
+		BoolVal, ClauseDatabase, ClauseDatabaseTools, Cnf, Encoder as _, Lit as BaseLit, VarRange,
+		Wcnf,
 	};
 	use pyo3::{prelude::*, types::PyIterator};
 
@@ -142,7 +146,7 @@ mod pindakaas {
 		/// Use :class:`pindakaas::bool_linear::TotalizerEncoder`, which is able to
 		/// encode all Boolean linear constraints.
 		TOTALIZER,
-		/// Use :class:`pindakaas::propositional_logic::TseitinEncdoer`, which is able to
+		/// Use :class:`pindakaas::propositional_logic::TseitinEncoder`, which is able to
 		/// encode propositional logic formulas.
 		TSEITIN,
 	}
@@ -243,6 +247,47 @@ mod pindakaas {
 			},
 		};
 		Ok(())
+	}
+
+	#[pyfunction]
+	fn _wrap_encode_constraint(
+		obj: &Bound<'_, PyAny>,
+		con: ConstraintArg,
+		enc: Option<Encoder>,
+		conditions: Vec<Lit>,
+	) -> Result {
+		struct PyDbWrapper<'a>(&'a Bound<'a, PyAny>);
+		impl ClauseDatabase for PyDbWrapper<'_> {
+			fn add_clause_from_slice(
+				&mut self,
+				clause: &[BaseLit],
+			) -> Result<(), pindakaas::Unsatisfiable> {
+				let clause: Vec<_> = clause.iter().map(|&l| Lit(l)).collect();
+				let res = self.0.call_method1("add_clause", (clause,));
+				match res {
+					Err(e) if e.is_instance_of::<Unsatisfiable>(self.0.py()) => {
+						Err(pindakaas::Unsatisfiable)
+					}
+					Err(e) => {
+						panic!("unexpected error in add_clause implementation: {}", e)
+					}
+					Ok(_) => Ok(()),
+				}
+			}
+
+			fn new_var_range(&mut self, len: usize) -> VarRange {
+				let tup = self
+					.0
+					.call_method1("new_var_range", (len,))
+					.expect("unexpected error in new_var_range implementation");
+				let (start, end): (Lit, Lit) = tup
+					.extract()
+					.expect("new_var_range did not return a tuple of two literals");
+				VarRange::new(start.0.var(), end.0.var())
+			}
+		}
+
+		encode_constraint_with_conditions(&mut PyDbWrapper(obj), con, enc, conditions)
 	}
 
 	impl BoolLinArg {
@@ -371,12 +416,9 @@ mod pindakaas {
 			Self(Default::default())
 		}
 
-		fn new_vars(&mut self, num_vars: usize) -> Vec<Lit> {
-			self.0
-				.new_var_range(num_vars)
-				.into_iter()
-				.map(|lit| Lit(lit.into()))
-				.collect()
+		fn new_var_range(&mut self, num_vars: usize) -> (Lit, Lit) {
+			let range = self.0.new_var_range(num_vars);
+			(Lit(range.start().into()), Lit(range.end().into()))
 		}
 
 		fn to_dimacs(&self) -> String {
@@ -555,6 +597,11 @@ mod pindakaas {
 			self.__xor__(other)
 		}
 
+		#[staticmethod]
+		fn from_raw(value: NonZeroI32) -> Self {
+			Self(BaseLit::from_raw(value))
+		}
+
 		/// Return whether the variable is negated
 		fn is_negated(&self) -> bool {
 			self.0.is_negated()
@@ -607,12 +654,9 @@ mod pindakaas {
 			Self(Default::default())
 		}
 
-		fn new_vars(&mut self, num_vars: usize) -> Vec<Lit> {
-			self.0
-				.new_var_range(num_vars)
-				.into_iter()
-				.map(|lit| Lit(lit.into()))
-				.collect()
+		fn new_var_range(&mut self, num_vars: usize) -> (Lit, Lit) {
+			let range = self.0.new_var_range(num_vars);
+			(Lit(range.start().into()), Lit(range.end().into()))
 		}
 
 		fn to_dimacs(&self) -> String {
@@ -706,13 +750,10 @@ mod pindakaas {
 				Self(Default::default())
 			}
 
-			fn new_vars(&mut self, num_vars: usize) -> Result<Vec<Lit>> {
+			fn new_var_range(&mut self, num_vars: usize) -> Result<(Lit, Lit)> {
 				let mut guard = self.0.lock()?;
-				Ok(guard
-					.new_var_range(num_vars)
-					.into_iter()
-					.map(|lit| Lit(lit.into()))
-					.collect())
+				let range = guard.new_var_range(num_vars);
+				Ok((Lit(range.start().into()), Lit(range.end().into())))
 			}
 
 			fn set_time_limit(&mut self, limit: Option<Duration>) -> Result {


### PR DESCRIPTION
- **feat(pyndakaas): implementation default `ClauseDatabase.add_encoding`**
- **refactor(pindakaas): naming of `Cnf` and `WCnf` information methods**
- **feat(pyndakaas): add clause and variable iteration for CNF and WCNF**
