### PR TITLE
fix(pindakaas): reintroduce `?Sized` removed by mistake

### DIFF
--- a/crates/pindakaas/src/bool_linear.rs
+++ b/crates/pindakaas/src/bool_linear.rs
@@ -219,11 +219,10 @@ impl AdderEncoder {
 	/// literals (full adder).
 	///
 	/// `output` can be either a literal, or a constant Boolean value.
-	fn carry_circuit<DB: ClauseDatabase + ?Sized>(
-		db: &mut DB,
-		input: &[Lit],
-		output: BoolVal,
-	) -> Result {
+	fn carry_circuit<Db>(db: &mut Db, input: &[Lit], output: BoolVal) -> Result
+	where
+		Db: ClauseDatabase + ?Sized,
+	{
 		match output {
 			BoolVal::Lit(carry) => match *input {
 				[a, b] => {
@@ -270,11 +269,10 @@ impl AdderEncoder {
 	/// literals (full adder).
 	///
 	/// `output` can be either a literal, or a constant Boolean value.
-	fn sum_circuit<DB: ClauseDatabase + AsDynClauseDatabase>(
-		db: &mut DB,
-		input: &[Lit],
-		output: BoolVal,
-	) -> Result {
+	fn sum_circuit<Db>(db: &mut Db, input: &[Lit], output: BoolVal) -> Result
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		match output {
 			BoolVal::Lit(sum) => match *input {
 				[a, b] => {
@@ -339,12 +337,15 @@ impl AdderEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, NormalizedBoolLinear> for AdderEncoder {
+impl<Db> Encoder<Db, NormalizedBoolLinear> for AdderEncoder
+where
+	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+{
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "adder_encoder", skip_all, fields(constraint = lin.trace_print()))
 	)]
-	fn encode(&self, db: &mut DB, lin: &NormalizedBoolLinear) -> Result {
+	fn encode(&self, db: &mut Db, lin: &NormalizedBoolLinear) -> Result {
 		debug_assert!(lin.cmp == LimitComp::LessEq || lin.cmp == LimitComp::Equal);
 		// The number of relevant bits in k
 		const ZERO: Coeff = 0;
@@ -614,12 +615,15 @@ impl BddEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, NormalizedBoolLinear> for BddEncoder {
+impl<Db> Encoder<Db, NormalizedBoolLinear> for BddEncoder
+where
+	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+{
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "bdd_encoder", skip_all, fields(constraint = lin.trace_print()))
 	)]
-	fn encode(&self, db: &mut DB, lin: &NormalizedBoolLinear) -> Result {
+	fn encode(&self, db: &mut Db, lin: &NormalizedBoolLinear) -> Result {
 		let xs = lin
 			.terms
 			.iter()
@@ -691,11 +695,10 @@ impl BoolLinAggregator {
 		any(feature = "tracing", test),
 		tracing::instrument(name = "aggregator", skip_all, fields(constraint = lin.trace_print()))
 	)]
-	pub fn aggregate<DB: ClauseDatabase + AsDynClauseDatabase>(
-		&self,
-		db: &mut DB,
-		lin: &BoolLinear,
-	) -> Result<BoolLinVariant> {
+	pub fn aggregate<Db>(&self, db: &mut Db, lin: &BoolLinear) -> Result<BoolLinVariant>
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		let mut k = lin.k;
 		// Aggregate multiple occurrences of the same
 		// variable.
@@ -1634,10 +1637,12 @@ impl From<LimitComp> for Comparator {
 }
 
 // Automatically implement Cardinality encoding when you can encode Linear constraints
-impl<DB: ClauseDatabase + ?Sized, Enc: Encoder<DB, NormalizedBoolLinear> + LinMarker>
-	Encoder<DB, Cardinality> for Enc
+impl<Db, Enc> Encoder<Db, Cardinality> for Enc
+where
+	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	Enc: Encoder<Db, NormalizedBoolLinear> + LinMarker,
 {
-	fn encode(&self, db: &mut DB, con: &Cardinality) -> Result {
+	fn encode(&self, db: &mut Db, con: &Cardinality) -> Result {
 		self.encode(db, &NormalizedBoolLinear::from(con.clone()))
 	}
 }
@@ -1667,14 +1672,16 @@ impl<Enc, Agg> LinearEncoder<Enc, Agg> {
 	}
 }
 
-impl<DB: ClauseDatabase + AsDynClauseDatabase, Enc: Encoder<DB, BoolLinVariant>>
-	Encoder<DB, BoolLinear> for LinearEncoder<Enc>
+impl<Db, Enc> Encoder<Db, BoolLinear> for LinearEncoder<Enc>
+where
+	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	Enc: Encoder<Db, BoolLinVariant>,
 {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "linear_encoder", skip_all, fields(constraint = lin.trace_print()))
 	)]
-	fn encode(&self, db: &mut DB, lin: &BoolLinear) -> Result {
+	fn encode(&self, db: &mut Db, lin: &BoolLinear) -> Result {
 		let variant = self.agg.aggregate(db, lin)?;
 		self.enc.encode(db, &variant)
 	}
@@ -1842,14 +1849,15 @@ impl<LinEnc, CardEnc, AmoEnc> StaticLinEncoder<LinEnc, CardEnc, AmoEnc> {
 	}
 }
 
-impl<
-		DB: ClauseDatabase + ?Sized,
-		LinEnc: Encoder<DB, NormalizedBoolLinear>,
-		CardEnc: Encoder<DB, Cardinality>,
-		AmoEnc: Encoder<DB, CardinalityOne>,
-	> Encoder<DB, BoolLinVariant> for StaticLinEncoder<LinEnc, CardEnc, AmoEnc>
+impl<Db, LinEnc, CardEnc, AmoEnc> Encoder<Db, BoolLinVariant>
+	for StaticLinEncoder<LinEnc, CardEnc, AmoEnc>
+where
+	Db: ClauseDatabase + ?Sized,
+	LinEnc: Encoder<Db, NormalizedBoolLinear>,
+	CardEnc: Encoder<Db, Cardinality>,
+	AmoEnc: Encoder<Db, CardinalityOne>,
 {
-	fn encode(&self, db: &mut DB, lin: &BoolLinVariant) -> Result {
+	fn encode(&self, db: &mut Db, lin: &BoolLinVariant) -> Result {
 		match &lin {
 			BoolLinVariant::Linear(lin) => self.lin_enc.encode(db, lin),
 			BoolLinVariant::Cardinality(card) => self.card_enc.encode(db, card),
@@ -1874,12 +1882,15 @@ impl SwcEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, NormalizedBoolLinear> for SwcEncoder {
+impl<Db> Encoder<Db, NormalizedBoolLinear> for SwcEncoder
+where
+	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+{
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "swc_encoder", skip_all, fields(constraint = lin.trace_print()))
 	)]
-	fn encode(&self, db: &mut DB, lin: &NormalizedBoolLinear) -> Result {
+	fn encode(&self, db: &mut Db, lin: &NormalizedBoolLinear) -> Result {
 		// self.cutoff = -1;
 		// self.add_consistency = true;
 		let mut model = Model::default();
@@ -1992,14 +2003,15 @@ impl TotalizerEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, NormalizedBoolLinear>
-	for TotalizerEncoder
+impl<Db> Encoder<Db, NormalizedBoolLinear> for TotalizerEncoder
+where
+	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
 {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "totalizer_encoder", skip_all, fields(constraint = lin.trace_print()))
 	)]
-	fn encode(&self, db: &mut DB, lin: &NormalizedBoolLinear) -> Result {
+	fn encode(&self, db: &mut Db, lin: &NormalizedBoolLinear) -> Result {
 		let xs = lin
 			.terms
 			.iter()

--- a/crates/pindakaas/src/cardinality.rs
+++ b/crates/pindakaas/src/cardinality.rs
@@ -66,10 +66,12 @@ impl From<CardinalityOne> for Cardinality {
 }
 
 // Automatically implement AtMostOne encoding when you can encode Cardinality constraints
-impl<DB: ClauseDatabase + ?Sized, Enc: Encoder<DB, Cardinality> + CardMarker>
-	Encoder<DB, CardinalityOne> for Enc
+impl<Db, Enc> Encoder<Db, CardinalityOne> for Enc
+where
+	Db: ClauseDatabase + ?Sized,
+	Enc: Encoder<Db, Cardinality> + CardMarker,
 {
-	fn encode(&self, db: &mut DB, con: &CardinalityOne) -> Result {
+	fn encode(&self, db: &mut Db, con: &CardinalityOne) -> Result {
 		self.encode(db, &Cardinality::from(con.clone()))
 	}
 }
@@ -95,12 +97,15 @@ impl Default for SortingNetworkEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, Cardinality> for SortingNetworkEncoder {
+impl<Db> Encoder<Db, Cardinality> for SortingNetworkEncoder
+where
+	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+{
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "sorting_network_encoder", skip_all, fields(constraint = card.trace_print()))
 	)]
-	fn encode(&self, db: &mut DB, card: &Cardinality) -> Result {
+	fn encode(&self, db: &mut Db, card: &Cardinality) -> Result {
 		self.sorted_encoder.encode(
 			db,
 			&Sorted::new(

--- a/crates/pindakaas/src/cardinality_one.rs
+++ b/crates/pindakaas/src/cardinality_one.rs
@@ -26,20 +26,20 @@ pub struct LadderEncoder {}
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct PairwiseEncoder {}
 
-pub(crate) fn at_least_one_clause<DB: ClauseDatabase + ?Sized>(
-	db: &mut DB,
-	card1: &CardinalityOne,
-) -> Result {
+pub(crate) fn at_least_one_clause<Db>(db: &mut Db, card1: &CardinalityOne) -> Result
+where
+	Db: ClauseDatabase + ?Sized,
+{
 	debug_assert_eq!(card1.cmp, LimitComp::Equal);
 	db.add_clause(card1.lits.iter().copied())
 }
 
-impl<DB: ClauseDatabase + ?Sized> Encoder<DB, CardinalityOne> for BitwiseEncoder {
+impl<Db: ClauseDatabase + ?Sized> Encoder<Db, CardinalityOne> for BitwiseEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "bitwise_encoder", skip_all, fields(constraint = card1.trace_print()))
 	)]
-	fn encode(&self, db: &mut DB, card1: &CardinalityOne) -> Result {
+	fn encode(&self, db: &mut Db, card1: &CardinalityOne) -> Result {
 		let size = card1.lits.len();
 		let bits = (usize::BITS - (size - 1).leading_zeros()) as usize;
 
@@ -95,12 +95,12 @@ impl Checker for CardinalityOne {
 	}
 }
 
-impl<DB: ClauseDatabase + ?Sized> Encoder<DB, CardinalityOne> for LadderEncoder {
+impl<Db: ClauseDatabase + ?Sized> Encoder<Db, CardinalityOne> for LadderEncoder {
 	#[cfg_attr(
 	any(feature = "tracing", test),
 	tracing::instrument(name = "ladder_encoder", skip_all, fields(constraint = card1.trace_print()))
 )]
-	fn encode(&self, db: &mut DB, card1: &CardinalityOne) -> Result {
+	fn encode(&self, db: &mut Db, card1: &CardinalityOne) -> Result {
 		// TODO could be slightly optimised to not introduce fixed lits
 		let mut a = db.new_lit(); // y_v-1
 		if card1.cmp == LimitComp::Equal {
@@ -123,12 +123,12 @@ impl<DB: ClauseDatabase + ?Sized> Encoder<DB, CardinalityOne> for LadderEncoder 
 	}
 }
 
-impl<DB: ClauseDatabase + ?Sized> Encoder<DB, CardinalityOne> for PairwiseEncoder {
+impl<Db: ClauseDatabase + ?Sized> Encoder<Db, CardinalityOne> for PairwiseEncoder {
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "pairwise_encoder", skip_all, fields(constraint = card1.trace_print()))
 	)]
-	fn encode(&self, db: &mut DB, card1: &CardinalityOne) -> Result {
+	fn encode(&self, db: &mut Db, card1: &CardinalityOne) -> Result {
 		// Add clause to ensure "at least one" literal holds
 		if card1.cmp == LimitComp::Equal {
 			at_least_one_clause(db, card1)?;

--- a/crates/pindakaas/src/integer.rs
+++ b/crates/pindakaas/src/integer.rs
@@ -117,12 +117,10 @@ pub(crate) fn display_dom(dom: &RangeList<Coeff>) -> String {
 	any(feature = "tracing", test),
 	tracing::instrument(name = "lex_geq", skip_all)
 )]
-pub(crate) fn lex_geq_const<DB: ClauseDatabase + ?Sized>(
-	db: &mut DB,
-	x: &[Option<Lit>],
-	k: PosCoeff,
-	bits: usize,
-) -> Result {
+pub(crate) fn lex_geq_const<Db>(db: &mut Db, x: &[Option<Lit>], k: PosCoeff, bits: usize) -> Result
+where
+	Db: ClauseDatabase + ?Sized,
+{
 	let k = as_binary(k, Some(bits as u32));
 	for i in 0..bits {
 		if k[i] && x[i].is_some() {
@@ -137,12 +135,10 @@ pub(crate) fn lex_geq_const<DB: ClauseDatabase + ?Sized>(
 	any(feature = "tracing", test),
 	tracing::instrument(name = "lex_lesseq_const", skip_all)
 )]
-pub(crate) fn lex_leq_const<DB: ClauseDatabase + ?Sized>(
-	db: &mut DB,
-	x: &[Option<Lit>],
-	k: PosCoeff,
-	bits: usize,
-) -> Result {
+pub(crate) fn lex_leq_const<Db>(db: &mut Db, x: &[Option<Lit>], k: PosCoeff, bits: usize) -> Result
+where
+	Db: ClauseDatabase + ?Sized,
+{
 	let k = as_binary(k, Some(bits as u32));
 	// For every zero bit in k:
 	// - either the `x` bit is also zero, or
@@ -162,13 +158,16 @@ pub(crate) fn lex_leq_const<DB: ClauseDatabase + ?Sized>(
 /// Constrains the slice `z`, to be the result of adding `x` to `y`, all encoded using the log encoding.
 ///
 /// TODO: Should this use the IntEncoding::Log input??
-pub(crate) fn log_enc_add<DB: ClauseDatabase + ?Sized>(
-	db: &mut DB,
+pub(crate) fn log_enc_add<Db>(
+	db: &mut Db,
 	x: &[Lit],
 	y: &[Lit],
 	cmp: &LimitComp,
 	z: &[Lit],
-) -> Result {
+) -> Result
+where
+	Db: ClauseDatabase + ?Sized,
+{
 	log_enc_add_(
 		db,
 		&x.iter().copied().map(BoolVal::from).collect_vec(),
@@ -179,13 +178,16 @@ pub(crate) fn log_enc_add<DB: ClauseDatabase + ?Sized>(
 }
 
 #[cfg_attr(any(feature = "tracing", test), tracing::instrument(name = "log_enc_add", skip_all, fields(constraint = format!("{x:?} + {y:?} {cmp} {z:?}"))))]
-pub(crate) fn log_enc_add_<DB: ClauseDatabase + ?Sized>(
-	db: &mut DB,
+pub(crate) fn log_enc_add_<Db>(
+	db: &mut Db,
 	x: &[BoolVal],
 	y: &[BoolVal],
 	cmp: &LimitComp,
 	z: &[BoolVal],
-) -> Result {
+) -> Result
+where
+	Db: ClauseDatabase + ?Sized,
+{
 	let n = itertools::max([x.len(), y.len(), z.len()]).unwrap();
 
 	let bit =
@@ -286,11 +288,10 @@ impl Checker for ImplicationChainConstraint {
 }
 
 impl ImplicationChainEncoder {
-	pub(crate) fn _encode<DB: ClauseDatabase + ?Sized>(
-		&mut self,
-		db: &mut DB,
-		ic: &ImplicationChainConstraint,
-	) -> Result {
+	pub(crate) fn _encode<Db>(&mut self, db: &mut Db, ic: &ImplicationChainConstraint) -> Result
+	where
+		Db: ClauseDatabase + ?Sized,
+	{
 		for (a, b) in ic.lits.iter().copied().tuple_windows() {
 			db.add_clause([!b, a])?;
 		}
@@ -299,12 +300,15 @@ impl ImplicationChainEncoder {
 }
 
 impl IntVar {
-	fn encode<DB: ClauseDatabase + AsDynClauseDatabase>(
+	fn encode<Db>(
 		&self,
-		db: &mut DB,
+		db: &mut Db,
 		views: &mut FxHashMap<(usize, Coeff), Lit>,
 		prefer_order: bool,
-	) -> IntVarEnc {
+	) -> IntVarEnc
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		if self.size() == 1 {
 			IntVarEnc::Const(*self.dom.lower_bound().unwrap())
 		} else {
@@ -405,12 +409,10 @@ impl Display for IntVar {
 }
 
 impl IntVarBin {
-	pub(crate) fn add<DB: ClauseDatabase + AsDynClauseDatabase>(
-		&self,
-		db: &mut DB,
-		encoder: &TernLeEncoder,
-		y: Coeff,
-	) -> Result<Self> {
+	pub(crate) fn add<Db>(&self, db: &mut Db, encoder: &TernLeEncoder, y: Coeff) -> Result<Self>
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		if y == 0 {
 			Ok(self.clone())
 		} else if GROUND_BINARY_AT_LB {
@@ -441,10 +443,10 @@ impl IntVarBin {
 		}
 	}
 
-	pub(crate) fn consistent<DB: ClauseDatabase + AsDynClauseDatabase>(
-		&self,
-		db: &mut DB,
-	) -> Result {
+	pub(crate) fn consistent<Db>(&self, db: &mut Db) -> Result
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		let encoder = TernLeEncoder::default();
 		if !GROUND_BINARY_AT_LB {
 			encoder.encode(
@@ -477,12 +479,10 @@ impl IntVarBin {
 	}
 
 	// TODO change to with_label or something
-	pub(crate) fn from_bounds<DB: ClauseDatabase + ?Sized>(
-		db: &mut DB,
-		lb: Coeff,
-		ub: Coeff,
-		lbl: String,
-	) -> Self {
+	pub(crate) fn from_bounds<Db>(db: &mut Db, lb: Coeff, ub: Coeff, lbl: String) -> Self
+	where
+		Db: ClauseDatabase + ?Sized,
+	{
 		Self {
 			xs: (0..IntVar::required_bits(lb, ub))
 				.map(|_i| new_named_lit!(db, format!("{}^{}", lbl, _i)))
@@ -587,16 +587,19 @@ impl Display for IntVarBin {
 }
 
 impl IntVarEnc {
-	pub(crate) fn add<DB: ClauseDatabase + AsDynClauseDatabase>(
+	pub(crate) fn add<Db>(
 		&self,
-		db: &mut DB,
+		db: &mut Db,
 		encoder: &TernLeEncoder,
 		y: &IntVarEnc,
 		lb: Option<Coeff>,
 		ub: Option<Coeff>,
 		// cmp: &LimitComp,
-		// enc: &'a mut dyn Encoder<DB, TernLeConstraint<'a, DB, C>>,
-	) -> Result<IntVarEnc> {
+		// enc: &'a mut dyn Encoder<Db, TernLeConstraint<'a, Db, C>>,
+	) -> Result<IntVarEnc>
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		let comp_lb = self.lb() + y.lb();
 		let lb = max(lb.unwrap_or(comp_lb), comp_lb);
 
@@ -662,10 +665,10 @@ impl IntVarEnc {
 		}
 	}
 
-	pub(crate) fn consistent<DB: ClauseDatabase + AsDynClauseDatabase>(
-		&self,
-		db: &mut DB,
-	) -> Result {
+	pub(crate) fn consistent<Db>(&self, db: &mut Db) -> Result
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		match self {
 			IntVarEnc::Ord(o) => o.consistent(db),
 			IntVarEnc::Bin(b) => b.consistent(db),
@@ -690,12 +693,10 @@ impl IntVarEnc {
 		}
 	}
 	/// Constructs (one or more) IntVar `ys` for linear expression `xs` so that ∑ xs ≦ ∑ ys
-	pub(crate) fn from_part<DB: ClauseDatabase + AsDynClauseDatabase>(
-		db: &mut DB,
-		xs: &Part,
-		ub: PosCoeff,
-		lbl: String,
-	) -> Vec<Self> {
+	pub(crate) fn from_part<Db>(db: &mut Db, xs: &Part, ub: PosCoeff, lbl: String) -> Vec<Self>
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		match xs {
 			Part::Amo(terms) => {
 				let terms: Vec<(Coeff, Lit)> = terms
@@ -884,7 +885,7 @@ impl IntVarOrd {
 		}
 	}
 
-	pub(crate) fn consistent<DB: ClauseDatabase + ?Sized>(&self, db: &mut DB) -> Result {
+	pub(crate) fn consistent<Db: ClauseDatabase + ?Sized>(&self, db: &mut Db) -> Result {
 		ImplicationChainEncoder::default()._encode(db, &self.consistency())
 	}
 
@@ -922,17 +923,15 @@ impl IntVarOrd {
 		self.dom.clone()
 	}
 
-	pub(crate) fn from_bounds<DB: ClauseDatabase + ?Sized>(
-		db: &mut DB,
-		lb: Coeff,
-		ub: Coeff,
-		lbl: String,
-	) -> Self {
+	pub(crate) fn from_bounds<Db>(db: &mut Db, lb: Coeff, ub: Coeff, lbl: String) -> Self
+	where
+		Db: ClauseDatabase + ?Sized,
+	{
 		Self::from_dom(db, (lb..=ub).into(), lbl)
 	}
 
-	pub(crate) fn from_dom<DB: ClauseDatabase + ?Sized>(
-		db: &mut DB,
+	pub(crate) fn from_dom<Db: ClauseDatabase + ?Sized>(
+		db: &mut Db,
 		dom: RangeList<Coeff>,
 		lbl: String,
 	) -> Self {
@@ -940,12 +939,15 @@ impl IntVarOrd {
 		Self::from_views(db, dom, vec![None; card - 1], lbl)
 	}
 
-	pub(crate) fn from_views<DB: ClauseDatabase + ?Sized>(
-		db: &mut DB,
+	pub(crate) fn from_views<Db>(
+		db: &mut Db,
 		dom: RangeList<Coeff>,
 		views: Vec<Option<Lit>>,
 		lbl: String,
-	) -> Self {
+	) -> Self
+	where
+		Db: ClauseDatabase + ?Sized,
+	{
 		assert!(!dom.is_empty());
 		assert_eq!(dom.card().unwrap() - 1, views.len(), "Expecting the same number of views as there are inequalities literals to represent the domain");
 
@@ -1250,11 +1252,10 @@ impl Model {
 		var
 	}
 
-	pub(crate) fn encode<DB: ClauseDatabase + AsDynClauseDatabase>(
-		&mut self,
-		db: &mut DB,
-		cutoff: Option<Coeff>,
-	) -> Result {
+	pub(crate) fn encode<Db>(&mut self, db: &mut Db, cutoff: Option<Coeff>) -> Result
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		let mut all_views = FxHashMap::default();
 		for con in &self.cons {
 			let Lin { xs, cmp } = con;
@@ -1384,12 +1385,15 @@ impl Display for TernLeConstraint<'_> {
 	}
 }
 
-impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, TernLeConstraint<'_>> for TernLeEncoder {
+impl<Db> Encoder<Db, TernLeConstraint<'_>> for TernLeEncoder
+where
+	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+{
 	#[cfg_attr(
 		any(feature = "tracing", test),
 		tracing::instrument(name = "tern_le_encoder", skip_all, fields(constraint = format!("{} + {} {} {}", tern.x, tern.y, tern.cmp, tern.z)))
 	)]
-	fn encode(&self, db: &mut DB, tern: &TernLeConstraint) -> Result {
+	fn encode(&self, db: &mut Db, tern: &TernLeConstraint) -> Result {
 		#[cfg(debug_assertions)]
 		{
 			const PRINT_TESTCASES: bool = false;
@@ -1833,13 +1837,10 @@ pub(crate) mod tests {
 		assert_eq!(c.geq(45), Formula::Atom(BoolVal::Const(false)));
 	}
 
-	fn get_bin_x<DB: ClauseDatabase + AsDynClauseDatabase>(
-		db: &mut DB,
-		lb: Coeff,
-		ub: Coeff,
-		consistent: bool,
-		lbl: String,
-	) -> IntVarEnc {
+	fn get_bin_x<Db>(db: &mut Db, lb: Coeff, ub: Coeff, consistent: bool, lbl: String) -> IntVarEnc
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		let x = IntVarBin::from_bounds(db, lb, ub, lbl);
 		if consistent {
 			x.consistent(db).unwrap();
@@ -1847,12 +1848,10 @@ pub(crate) mod tests {
 		IntVarEnc::Bin(x)
 	}
 
-	fn get_ord_x<DB: ClauseDatabase + ?Sized>(
-		db: &mut DB,
-		dom: RangeList<Coeff>,
-		consistent: bool,
-		lbl: String,
-	) -> IntVarEnc {
+	fn get_ord_x<Db>(db: &mut Db, dom: RangeList<Coeff>, consistent: bool, lbl: String) -> IntVarEnc
+	where
+		Db: ClauseDatabase + ?Sized,
+	{
 		let x = IntVarOrd::from_dom(db, dom, lbl);
 		if consistent {
 			x.consistent(db).unwrap();

--- a/crates/pindakaas/src/lib.rs
+++ b/crates/pindakaas/src/lib.rs
@@ -249,8 +249,8 @@ enum Dimacs {
 }
 
 /// Encoder is the central trait implemented for all the encoding algorithms
-pub trait Encoder<DB: ClauseDatabase + ?Sized, Constraint: ?Sized> {
-	fn encode(&self, db: &mut DB, con: &Constraint) -> Result;
+pub trait Encoder<Db: ClauseDatabase + ?Sized, Constraint: ?Sized> {
+	fn encode(&self, db: &mut Db, con: &Constraint) -> Result;
 }
 
 /// IntEncoding is a enumerated type use to represent Boolean encodings of
@@ -692,7 +692,7 @@ impl Mul<Lit> for Coeff {
 	}
 }
 
-impl<DB: ClauseDatabase + ?Sized> ClauseDatabaseTools for DB {}
+impl<Db: ClauseDatabase + ?Sized> ClauseDatabaseTools for Db {}
 
 impl<F: Fn(Lit) -> bool> Valuation for F {
 	fn value(&self, lit: Lit) -> bool {

--- a/crates/pindakaas/src/propositional_logic.rs
+++ b/crates/pindakaas/src/propositional_logic.rs
@@ -271,7 +271,7 @@ impl Formula<BoolVal> {
 impl Formula<Lit> {
 	/// Helper function to bind the (sub) formula to a name (literal) for the
 	/// tseitin encoding.
-	fn bind<DB: ClauseDatabase + ?Sized>(&self, db: &mut DB, name: Option<Lit>) -> Result<Lit> {
+	fn bind<Db: ClauseDatabase + ?Sized>(&self, db: &mut Db, name: Option<Lit>) -> Result<Lit> {
 		Ok(match self {
 			Formula::Atom(lit) => {
 				if let Some(name) = name {
@@ -670,8 +670,11 @@ impl<Base> Not for Formula<Base> {
 	}
 }
 
-impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, Formula<BoolVal>> for TseitinEncoder {
-	fn encode(&self, db: &mut DB, con: &Formula<BoolVal>) -> Result {
+impl<Db> Encoder<Db, Formula<BoolVal>> for TseitinEncoder
+where
+	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+{
+	fn encode(&self, db: &mut Db, con: &Formula<BoolVal>) -> Result {
 		match con.clone().resolve() {
 			Err(false) => Err(Unsatisfiable),
 			Err(true) => Ok(()),
@@ -680,8 +683,11 @@ impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, Formula<BoolVal>> for
 	}
 }
 
-impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, Formula<Lit>> for TseitinEncoder {
-	fn encode(&self, db: &mut DB, f: &Formula<Lit>) -> Result {
+impl<Db> Encoder<Db, Formula<Lit>> for TseitinEncoder
+where
+	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+{
+	fn encode(&self, db: &mut Db, f: &Formula<Lit>) -> Result {
 		match f {
 			Formula::Atom(l) => db.add_clause([*l]),
 			Formula::Not(f) => match f.as_ref() {

--- a/crates/pindakaas/src/sorted.rs
+++ b/crates/pindakaas/src/sorted.rs
@@ -76,15 +76,18 @@ impl Checker for Sorted<'_> {
 }
 
 impl SortedEncoder {
-	fn comp<DB: ClauseDatabase + AsDynClauseDatabase>(
+	fn comp<Db>(
 		&self,
-		db: &mut DB,
+		db: &mut Db,
 		x: &IntVarEnc,
 		y: &IntVarEnc,
 		cmp: &LimitComp,
 		z: &IntVarEnc,
 		c: Coeff,
-	) -> Result {
+	) -> Result
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		let cmp = self.overwrite_recursive_cmp.as_ref().unwrap_or(cmp);
 		let c1 = c;
 		let c2 = c + 1;
@@ -111,15 +114,18 @@ impl SortedEncoder {
 		self
 	}
 
-	fn merged<DB: ClauseDatabase + AsDynClauseDatabase>(
+	fn merged<Db>(
 		&self,
-		db: &mut DB,
+		db: &mut Db,
 		x1: &IntVarEnc,
 		x2: &IntVarEnc,
 		cmp: &LimitComp,
 		y: &IntVarEnc,
 		_lvl: usize,
-	) -> Result {
+	) -> Result
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		let (a, b, c) = (x1.ub(), x2.ub(), y.ub());
 		let strat = if let SortedStrategy::Mixed(lambda) = &self.strategy {
 			let mut cache = self.strategy_cost_cache.lock().unwrap();
@@ -194,12 +200,10 @@ impl SortedEncoder {
 		}
 	}
 
-	fn next_int_var<DB: ClauseDatabase + AsDynClauseDatabase>(
-		&self,
-		db: &mut DB,
-		ub: Coeff,
-		lbl: String,
-	) -> IntVarEnc {
+	fn next_int_var<Db>(&self, db: &mut Db, ub: Coeff, lbl: String) -> IntVarEnc
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		// TODO We always have the view x>=1 <-> y>=1, which is now realized using equiv
 		if ub == 0 {
 			IntVarEnc::Const(0)
@@ -213,14 +217,17 @@ impl SortedEncoder {
 	}
 
 	/// The sorted/merged base case of x1{0,1}+x2{0,1}<=y{0,1,2}
-	fn smerge<DB: ClauseDatabase + AsDynClauseDatabase>(
+	fn smerge<Db>(
 		&self,
-		db: &mut DB,
+		db: &mut Db,
 		x1: &IntVarEnc,
 		x2: &IntVarEnc,
 		cmp: &LimitComp,
 		y: &IntVarEnc,
-	) -> Result {
+	) -> Result
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		// we let x2 take the place of z_ceil, so we need to add 1 to both sides
 		let x2 = x2.add(
 			db,
@@ -239,15 +246,18 @@ impl SortedEncoder {
 		self.comp(db, x1, &x2, cmp, &y, 1)
 	}
 
-	fn sort<DB: ClauseDatabase + AsDynClauseDatabase>(
+	fn sort<Db>(
 		&self,
-		db: &mut DB,
+		db: &mut Db,
 		xs: &[IntVarEnc],
 		cmp: &LimitComp,
 		ub: Coeff,
 		lbl: String,
 		_lvl: usize,
-	) -> Option<IntVarEnc> {
+	) -> Option<IntVarEnc>
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		match xs {
 			[] => None,
 			[x] => Some(x.clone()),
@@ -259,14 +269,17 @@ impl SortedEncoder {
 		}
 	}
 
-	fn sorted<DB: ClauseDatabase + AsDynClauseDatabase>(
+	fn sorted<Db>(
 		&self,
-		db: &mut DB,
+		db: &mut Db,
 		xs: &[IntVarEnc],
 		cmp: &LimitComp,
 		y: &IntVarEnc,
 		_lvl: usize,
-	) -> Result {
+	) -> Result
+	where
+		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	{
 		let (n, m) = (xs.len(), y.ub());
 		let direct = false;
 
@@ -388,8 +401,8 @@ impl Default for SortedEncoder {
 	}
 }
 
-impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, Sorted<'_>> for SortedEncoder {
-	fn encode(&self, db: &mut DB, sorted: &Sorted) -> Result {
+impl<Db: ClauseDatabase + AsDynClauseDatabase + ?Sized> Encoder<Db, Sorted<'_>> for SortedEncoder {
+	fn encode(&self, db: &mut Db, sorted: &Sorted) -> Result {
 		let xs = sorted
 			.xs
 			.iter()
@@ -408,8 +421,11 @@ impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, Sorted<'_>> for Sorte
 	}
 }
 
-impl<DB: ClauseDatabase + AsDynClauseDatabase> Encoder<DB, TernLeConstraint<'_>> for SortedEncoder {
-	fn encode(&self, db: &mut DB, tern: &TernLeConstraint) -> Result {
+impl<Db> Encoder<Db, TernLeConstraint<'_>> for SortedEncoder
+where
+	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+{
+	fn encode(&self, db: &mut Db, tern: &TernLeConstraint) -> Result {
 		let TernLeConstraint { x, y, cmp, z } = tern;
 		if tern.is_fixed()? {
 			Ok(())

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -182,12 +182,15 @@ mod pindakaas {
 
 	/// Same `encode_constraint`, but evaluates the conditions if not empty. This prevents
 	/// costly virtual method access if this were done inside `encode_constraint`
-	fn encode_constraint_with_conditions<Db: ClauseDatabase>(
+	fn encode_constraint_with_conditions<Db>(
 		db: &mut Db,
 		con: ConstraintArg,
 		enc: Option<Encoder>,
 		conditions: Vec<Lit>,
-	) -> Result {
+	) -> Result
+	where
+		Db: ClauseDatabase,
+	{
 		if conditions.is_empty() {
 			encode_constraint(db, con, enc)
 		} else {
@@ -201,11 +204,10 @@ mod pindakaas {
 
 	/// Internal function to help with the encoding of a constraint given an
 	/// optional encoder.
-	fn encode_constraint<Db: ClauseDatabase>(
-		db: &mut Db,
-		con: ConstraintArg,
-		enc: Option<Encoder>,
-	) -> Result {
+	fn encode_constraint<Db>(db: &mut Db, con: ConstraintArg, enc: Option<Encoder>) -> Result
+	where
+		Db: ClauseDatabase,
+	{
 		let invalid_enc = |con_ty, enc| {
 			Err(InvalidEncoder::new_err(format!(
 				"Unable to encode object of type `{con_ty}' using {enc:?}"


### PR DESCRIPTION
This incorrect change was introduced in 653be06c7e63178fc57241d24932d8f5a8f0ee13.

I also took this opportunity to change `DB` to `Db` and move conditions
into a `where` clause if the signature spans more than one line.
