### PR TITLE
chore: release

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,7 @@ build:
     install:
       - pip install --upgrade pip
       - pip install --group ./crates/pyndakaas/pyproject.toml:docs
+      - pip install ./crates/pyndakaas/
 
 # Build documentation in the "crates/pyndakaas/docs/" directory with Sphinx
 sphinx:

--- a/crates/pindakaas-cadical/CHANGELOG.md
+++ b/crates/pindakaas-cadical/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.1.0...pindakaas-cadical-v0.2.0) - 2025-09-09
+
+### Added
+
+- add bindings to CaDiCaL's proof tracer interface
+- allow the separate PersistentAssignmentListener
+- redesign the way that IPASIR solvers are defined in pindakaas
+
 ## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-cadical-v0.1.0) - 2025-07-09
 
 ### Added

--- a/crates/pindakaas-cadical/Cargo.toml
+++ b/crates/pindakaas-cadical/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-cadical"
 description = "build of the Cadical SAT solver for the pindakaas crate"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT"
 
 include = [

--- a/crates/pindakaas-intel-sat/CHANGELOG.md
+++ b/crates/pindakaas-intel-sat/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-intel-sat-v0.1.0...pindakaas-intel-sat-v0.2.0) - 2025-09-09
+
+### Added
+
+- redesign the way that IPASIR solvers are defined in pindakaas
+
 ## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-intel-sat-v0.1.0) - 2025-07-09
 
 ### Added

--- a/crates/pindakaas-intel-sat/Cargo.toml
+++ b/crates/pindakaas-intel-sat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-intel-sat"
 description = "build of the Intel SAT solver for the pindakaas crate"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT"
 
 build = "build.rs"

--- a/crates/pindakaas-kissat/CHANGELOG.md
+++ b/crates/pindakaas-kissat/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.1.0...pindakaas-kissat-v0.2.0) - 2025-09-09
+
+### Added
+
+- redesign the way that IPASIR solvers are defined in pindakaas
+
+### Fixed
+
+- *(pindakaas-kissat)* ensure MSVC compatibility
+
 ## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-kissat-v0.1.0) - 2025-07-09
 
 ### Added

--- a/crates/pindakaas-kissat/Cargo.toml
+++ b/crates/pindakaas-kissat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-kissat"
 description = "build of the Kissat SAT solver for the pindakaas crate"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT"
 
 build = "build.rs"

--- a/crates/pindakaas/CHANGELOG.md
+++ b/crates/pindakaas/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.1.0...pindakaas-v0.2.0) - 2025-09-09
+
+### Added
+
+- *(pyndakaas)* add support for kissat solver
+- *(pindakaas)* add `phase` and `unphase` to `ExternalPropagation`
+- add bindings to CaDiCaL's proof tracer interface
+- allow the separate PersistentAssignmentListener
+- redesign the way that IPASIR solvers are defined in pindakaas
+
+### Fixed
+
+- *(pindakaas)* reintroduce `?Sized` removed by mistake
+- *(pyndakaas)* python `failed` call ([#135](https://github.com/pindakaashq/pindakaas/pull/135))
+
+### Other
+
+- *(pindakaas)* naming of `Cnf` and `WCnf` information methods
+- *(pindakaas)* remove iset dependency
+- *(pindakaas)* add anonymous lifetime for SymResult
+- *(pindakaas)* reconsider the naming of solver related traits
+
 ## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pindakaas-cadical-v0.1.0) - 2025-07-09
 
 ### Added

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas"
 description = "Encoding Integer and Pseudo Boolean constraints into CNF"
-version = "0.1.0"
+version = "0.2.0"
 
 authors.workspace = true
 edition.workspace = true
@@ -22,9 +22,9 @@ libloading = { version = "0.8", optional = true }
 tracing = { workspace = true, optional = true }
 
 # Optional Solver Interfaces
-pindakaas-cadical = { version = "0.1.0", path = "../pindakaas-cadical", optional = true }
-pindakaas-intel-sat = { version = "0.1.0", path = "../pindakaas-intel-sat", optional = true }
-pindakaas-kissat = { version = "0.1.0", path = "../pindakaas-kissat", optional = true }
+pindakaas-cadical = { version = "0.2.0", path = "../pindakaas-cadical", optional = true }
+pindakaas-intel-sat = { version = "0.2.0", path = "../pindakaas-intel-sat", optional = true }
+pindakaas-kissat = { version = "0.2.0", path = "../pindakaas-kissat", optional = true }
 splr = { version = "0.17", optional = true }
 
 [dev-dependencies]

--- a/crates/pyndakaas/CHANGELOG.md
+++ b/crates/pyndakaas/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.1.0...pyndakaas-v0.1.1) - 2025-09-09
+
+### Added
+
+- *(pyndakaas)* add support for kissat solver
+- *(pyndakaas)* add clause and variable iteration for CNF and WCNF
+- *(pyndakaas)* implementation default `ClauseDatabase.add_encoding`
+- add bindings to CaDiCaL's proof tracer interface
+- redesign the way that IPASIR solvers are defined in pindakaas
+
+### Fixed
+
+- *(pindakaas)* reintroduce `?Sized` removed by mistake
+- *(pyndakaas)* python `failed` call ([#135](https://github.com/pindakaashq/pindakaas/pull/135))
+
+### Other
+
+- *(pyndakaas)* resolve build problems for Python documentation
+- *(deps)* update pyo3 requirement from 0.25.1 to 0.26.0
+- *(pyndakaas)* remove `Mutex` wrapper for `CaDiCaLInner`
+- *(pindakaas)* reconsider the naming of solver related traits
+- update pyo3 requirement from 0.24.0 to 0.25.1 ([#129](https://github.com/pindakaashq/pindakaas/pull/129))
+
 ## [0.1.0](https://github.com/pindakaashq/pindakaas/releases/tag/pyndakaas-v0.1.0) - 2025-07-08
 
 ### Added

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyndakaas"
 description = "Python bindings for the pindakaas crate"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 authors.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.14"
-pindakaas = { version = "0.1.0", path = "../pindakaas", features = ["kissat"] }
+pindakaas = { version = "0.2.0", path = "../pindakaas", features = ["kissat"] }
 pyo3 = "0.26.0"
 
 [lints]

--- a/crates/pyndakaas/python/pindakaas/solver.py
+++ b/crates/pyndakaas/python/pindakaas/solver.py
@@ -11,7 +11,8 @@ from .pindakaas.solver import CaDiCaLInner, KissatInner, Status
 
 
 class Result(ABC):
-    """The Result object returned after calling `solve()`. It allows access to e.g.
+    """
+    The Result object returned after calling `solve()`. It allows access to e.g.
     solver status and the values of variables.
     """
 
@@ -23,7 +24,8 @@ class Result(ABC):
 
     @abstractmethod
     def value(self, lit: Lit) -> Optional[bool]:
-        """Return value for literal `lit`, or `None` if `lit` is assigned.
+        """
+        Return value for literal `lit`, or `None` if `lit` is assigned.
 
         :param lit: the literal for which to return the value
         :return: the value of `lit` if assigned
@@ -32,7 +34,8 @@ class Result(ABC):
 
     @abstractmethod
     def failed(self, lit: Lit) -> Optional[bool]:
-        """Check if the given assumption literal was used to prove the unsatisfiability
+        """
+        Check if the given assumption literal was used to prove the unsatisfiability
         of the formula under the assumptions used for the last SAT search. Note that for
         literals `lit` which are not assumption literals, the behavior of is not
         specified.
@@ -60,7 +63,8 @@ class Solver(ClauseDatabase):
         assumptions: Optional[Iterable[Lit]] = None,
         time_limit: Optional[timedelta] = None,
     ) -> Iterator[Result]:
-        """Solve the current `ClauseDatabase`.
+        """
+        Solve the current `ClauseDatabase`.
 
         :param assumptions: an optional iterable of assumptions literals which must hold
         for this solve call


### PR DESCRIPTION



## 🤖 New release

* `pindakaas-cadical`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `pindakaas-intel-sat`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `pindakaas-kissat`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `pindakaas`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `pyndakaas`: 0.1.0 -> 0.1.1

### ⚠ `pindakaas-cadical` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_missing.ron

Failed in:
  function pindakaas_cadical::ipasir_assume, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:39
  function pindakaas_cadical::ipasir_failed, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:48
  function pindakaas_cadical::ipasir_connect_external_propagator, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:97
  function pindakaas_cadical::ipasir_remove_observed_var, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:138
  function pindakaas_cadical::ipasir_force_backtrack, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:147
  function pindakaas_cadical::ipasir_signature, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:27
  function pindakaas_cadical::ipasir_add, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:36
  function pindakaas_cadical::ipasir_val, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:45
  function pindakaas_cadical::ipasir_set_learn, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:58
  function pindakaas_cadical::ipasir_add_observed_var, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:135
  function pindakaas_cadical::ipasir_is_decision, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:144
  function pindakaas_cadical::ccadical_enable_proof, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:171
  function pindakaas_cadical::ipasir_release, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:33
  function pindakaas_cadical::ipasir_solve, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:42
  function pindakaas_cadical::ipasir_set_terminate, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:51
  function pindakaas_cadical::ipasir_disconnect_external_propagator, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:132
  function pindakaas_cadical::ipasir_reset_observed_vars, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:141
  function pindakaas_cadical::ipasir_init, previously in file /tmp/.tmplioJAK/pindakaas-cadical/src/lib.rs:30

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_parameter_count_changed.ron

Failed in:
  pindakaas_cadical::ccadical_connect_external_propagator now takes 2 parameters instead of 15, in /tmp/.tmphqr05C/pindakaas/crates/pindakaas-cadical/src/lib.rs:116
```

### ⚠ `pindakaas-intel-sat` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_missing.ron

Failed in:
  function pindakaas_intel_sat::ipasir_set_terminate, previously in file /tmp/.tmplioJAK/pindakaas-intel-sat/src/lib.rs:51
  function pindakaas_intel_sat::ipasir_signature, previously in file /tmp/.tmplioJAK/pindakaas-intel-sat/src/lib.rs:27
  function pindakaas_intel_sat::ipasir_add, previously in file /tmp/.tmplioJAK/pindakaas-intel-sat/src/lib.rs:36
  function pindakaas_intel_sat::ipasir_val, previously in file /tmp/.tmplioJAK/pindakaas-intel-sat/src/lib.rs:45
  function pindakaas_intel_sat::ipasir_set_learn, previously in file /tmp/.tmplioJAK/pindakaas-intel-sat/src/lib.rs:58
  function pindakaas_intel_sat::ipasir_init, previously in file /tmp/.tmplioJAK/pindakaas-intel-sat/src/lib.rs:30
  function pindakaas_intel_sat::ipasir_assume, previously in file /tmp/.tmplioJAK/pindakaas-intel-sat/src/lib.rs:39
  function pindakaas_intel_sat::ipasir_failed, previously in file /tmp/.tmplioJAK/pindakaas-intel-sat/src/lib.rs:48
  function pindakaas_intel_sat::ipasir_release, previously in file /tmp/.tmplioJAK/pindakaas-intel-sat/src/lib.rs:33
  function pindakaas_intel_sat::ipasir_solve, previously in file /tmp/.tmplioJAK/pindakaas-intel-sat/src/lib.rs:42
```

### ⚠ `pindakaas-kissat` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_missing.ron

Failed in:
  function pindakaas_kissat::kissat_assume, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:11
  function pindakaas_kissat::kissat_val, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:13
  function pindakaas_kissat::ipasir_init, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:30
  function pindakaas_kissat::ipasir_assume, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:39
  function pindakaas_kissat::ipasir_failed, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:48
  function pindakaas_kissat::ipasir_signature, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:27
  function pindakaas_kissat::ipasir_add, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:36
  function pindakaas_kissat::ipasir_val, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:45
  function pindakaas_kissat::ipasir_set_learn, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:58
  function pindakaas_kissat::kissat_failed, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:14
  function pindakaas_kissat::ipasir_release, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:33
  function pindakaas_kissat::kissat_set_learn, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:20
  function pindakaas_kissat::ipasir_solve, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:42
  function pindakaas_kissat::ipasir_set_terminate, previously in file /tmp/.tmplioJAK/pindakaas-kissat/src/lib.rs:51
```

### ⚠ `pindakaas` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type IntelSat is no longer UnwindSafe, in /tmp/.tmphqr05C/pindakaas/crates/pindakaas/src/solver/intel_sat.rs:17
  type IntelSat is no longer RefUnwindSafe, in /tmp/.tmphqr05C/pindakaas/crates/pindakaas/src/solver/intel_sat.rs:17
  type Cadical is no longer UnwindSafe, in /tmp/.tmphqr05C/pindakaas/crates/pindakaas/src/solver/cadical.rs:41
  type Cadical is no longer RefUnwindSafe, in /tmp/.tmphqr05C/pindakaas/crates/pindakaas/src/solver/cadical.rs:41
  type Cadical is no longer Send, in /tmp/.tmphqr05C/pindakaas/crates/pindakaas/src/solver/cadical.rs:41
  type IpasirSolver is no longer UnwindSafe, in /tmp/.tmphqr05C/pindakaas/crates/pindakaas/src/solver/libloading.rs:36
  type IpasirSolver is no longer RefUnwindSafe, in /tmp/.tmphqr05C/pindakaas/crates/pindakaas/src/solver/libloading.rs:36
  type Kissat is no longer UnwindSafe, in /tmp/.tmphqr05C/pindakaas/crates/pindakaas/src/solver/kissat.rs:16
  type Kissat is no longer RefUnwindSafe, in /tmp/.tmphqr05C/pindakaas/crates/pindakaas/src/solver/kissat.rs:16

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_missing.ron

Failed in:
  enum pindakaas::solver::SlvTermSignal, previously in file /tmp/.tmplioJAK/pindakaas/src/solver.rs:56

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/feature_missing.ron

Failed in:
  feature pindakaas-derive in the package's Cargo.toml

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  LinearEncoder::add_linear_aggregater, previously in file /tmp/.tmplioJAK/pindakaas/src/bool_linear.rs:1630
  Cadical::enable_proof, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/cadical.rs:68
  Wcnf::clauses, previously in file /tmp/.tmplioJAK/pindakaas/src/lib.rs:1079

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct pindakaas::solver::kissat::KissatSol, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/kissat.rs:7
  struct pindakaas::solver::intel_sat::IntelSatSol, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/intel_sat.rs:7
  struct pindakaas::solver::intel_sat::IntelSatFailed, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/intel_sat.rs:7
  struct pindakaas::solver::cadical::PropagatingCadical, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/cadical.rs:11
  struct pindakaas::solver::cadical::CadicalSol, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/cadical.rs:11
  struct pindakaas::solver::cadical::CadicalFailed, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/cadical.rs:11

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_method_added.ron

Failed in:
  trait method pindakaas::solver::propagation::SolvingActions::new_observed_var in file /tmp/.tmphqr05C/pindakaas/crates/pindakaas/src/solver/propagation.rs:214
  trait method pindakaas::solver::propagation::SolvingActions::phase in file /tmp/.tmphqr05C/pindakaas/crates/pindakaas/src/solver/propagation.rs:217
  trait method pindakaas::solver::propagation::SolvingActions::unphase in file /tmp/.tmphqr05C/pindakaas/crates/pindakaas/src/solver/propagation.rs:221

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_method_missing.ron

Failed in:
  method is_check_only of trait Propagator, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/propagation.rs:111
  method reason_persistence of trait Propagator, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/propagation.rs:121
  method enable_persistent_assignments of trait Propagator, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/propagation.rs:134
  method notify_persistent_assignment of trait Propagator, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/propagation.rs:152
  method signature of trait Solver, previously in file /tmp/.tmplioJAK/pindakaas/src/solver.rs:81
  method new_var of trait SolvingActions, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/propagation.rs:217
  method new_lit of trait SolvingActions, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/propagation.rs:219

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_missing.ron

Failed in:
  trait pindakaas::solver::SolveAssuming, previously in file /tmp/.tmplioJAK/pindakaas/src/solver.rs:61
  trait pindakaas::solver::propagation::WithPropagator, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/propagation.rs:226
  trait pindakaas::solver::FailedAssumtions, previously in file /tmp/.tmplioJAK/pindakaas/src/solver.rs:32
  trait pindakaas::solver::TermCallback, previously in file /tmp/.tmplioJAK/pindakaas/src/solver.rs:90
  trait pindakaas::solver::propagation::PropagatingSolver, previously in file /tmp/.tmplioJAK/pindakaas/src/solver/propagation.rs:42
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pindakaas-cadical`

<blockquote>

## [0.2.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.1.0...pindakaas-cadical-v0.2.0) - 2025-09-09

### Added

- add bindings to CaDiCaL's proof tracer interface
- allow the separate PersistentAssignmentListener
- redesign the way that IPASIR solvers are defined in pindakaas
</blockquote>

## `pindakaas-intel-sat`

<blockquote>

## [0.2.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-intel-sat-v0.1.0...pindakaas-intel-sat-v0.2.0) - 2025-09-09

### Added

- redesign the way that IPASIR solvers are defined in pindakaas
</blockquote>

## `pindakaas-kissat`

<blockquote>

## [0.2.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.1.0...pindakaas-kissat-v0.2.0) - 2025-09-09

### Added

- redesign the way that IPASIR solvers are defined in pindakaas

### Fixed

- *(pindakaas-kissat)* ensure MSVC compatibility
</blockquote>

## `pindakaas`

<blockquote>

## [0.2.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.1.0...pindakaas-v0.2.0) - 2025-09-09

### Added

- *(pyndakaas)* add support for kissat solver
- *(pindakaas)* add `phase` and `unphase` to `ExternalPropagation`
- add bindings to CaDiCaL's proof tracer interface
- allow the separate PersistentAssignmentListener
- redesign the way that IPASIR solvers are defined in pindakaas

### Fixed

- *(pindakaas)* reintroduce `?Sized` removed by mistake
- *(pyndakaas)* python `failed` call ([#135](https://github.com/pindakaashq/pindakaas/pull/135))

### Other

- *(pindakaas)* naming of `Cnf` and `WCnf` information methods
- *(pindakaas)* remove iset dependency
- *(pindakaas)* add anonymous lifetime for SymResult
- *(pindakaas)* reconsider the naming of solver related traits
</blockquote>

## `pyndakaas`

<blockquote>

## [0.1.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.1.0...pyndakaas-v0.1.1) - 2025-09-09

### Added

- *(pyndakaas)* add support for kissat solver
- *(pyndakaas)* add clause and variable iteration for CNF and WCNF
- *(pyndakaas)* implementation default `ClauseDatabase.add_encoding`
- add bindings to CaDiCaL's proof tracer interface
- redesign the way that IPASIR solvers are defined in pindakaas

### Fixed

- *(pindakaas)* reintroduce `?Sized` removed by mistake
- *(pyndakaas)* python `failed` call ([#135](https://github.com/pindakaashq/pindakaas/pull/135))

### Other

- *(pyndakaas)* resolve build problems for Python documentation
- *(deps)* update pyo3 requirement from 0.25.1 to 0.26.0
- *(pyndakaas)* remove `Mutex` wrapper for `CaDiCaLInner`
- *(pindakaas)* reconsider the naming of solver related traits
- update pyo3 requirement from 0.24.0 to 0.25.1 ([#129](https://github.com/pindakaashq/pindakaas/pull/129))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).