### PR TITLE
Make `new_var_range` return consistent

### DIFF
--- a/crates/pindakaas/src/lib.rs
+++ b/crates/pindakaas/src/lib.rs
@@ -227,7 +227,7 @@ pub mod trace;
 
 use std::{
 	clone::Clone,
-	cmp::{max, Eq, Ordering},
+	cmp::{Eq, Ordering},
 	error::Error,
 	fmt::{self, Display},
 	fs::File,
@@ -1227,14 +1227,23 @@ impl VarRange {
 	/// # use pindakaas::VarRange;
 	/// assert!(VarRange::empty().is_empty());
 	/// ```
-	pub fn is_empty(&self) -> bool {
-		self.start > self.end
+	pub const fn is_empty(&self) -> bool {
+		self.len() == 0
 	}
 
 	/// Returns an iterator of the Boolean variables in the range represented as
 	/// [`Lit`]s.
 	pub fn iter_lits(&mut self) -> impl Iterator<Item = Lit> + '_ {
 		self.map(Lit::from)
+	}
+
+	/// Returns the number of variables in the range.
+	pub const fn len(&self) -> usize {
+		let len = self.end.0.get() - self.start.0.get() + 1;
+		if len < 0 {
+			return 0;
+		}
+		len as usize
 	}
 
 	/// Create a range starting from `start` and ending at `end` (inclusive)
@@ -1269,9 +1278,7 @@ impl DoubleEndedIterator for VarRange {
 
 impl ExactSizeIterator for VarRange {
 	fn len(&self) -> usize {
-		let (lower, upper) = self.size_hint();
-		debug_assert_eq!(upper, Some(lower));
-		lower
+		self.len()
 	}
 }
 
@@ -1301,9 +1308,10 @@ impl Iterator for VarRange {
 			None
 		}
 	}
+
 	fn size_hint(&self) -> (usize, Option<usize>) {
-		let size = max(self.end.0.get() - self.start.0.get() + 1, 0) as usize;
-		(size, Some(size))
+		let len = self.len();
+		(len, Some(len))
 	}
 }
 

--- a/crates/pyndakaas/python/tests/test_solving.py
+++ b/crates/pyndakaas/python/tests/test_solving.py
@@ -44,3 +44,8 @@ def test_kissat():
         assert vx is not None
         assert vy is not None
         assert vx != vy
+
+
+def test_issue_159():
+    slv = pindakaas.solver.CaDiCaL()
+    assert len(slv.new_vars(1)) == 1

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -439,9 +439,9 @@ mod pindakaas {
 			Self(Default::default())
 		}
 
-		fn new_var_range(&mut self, num_vars: usize) -> VarRange {
+		fn new_var_range(&mut self, num_vars: usize) -> PyResult<VarRange> {
 			let range = self.0.new_var_range(num_vars);
-			VarRange(range)
+			Ok(VarRange(range))
 		}
 
 		fn to_dimacs(&self) -> String {
@@ -652,6 +652,10 @@ mod pindakaas {
 			slf
 		}
 
+		fn __len__(&self) -> usize {
+			self.0.len()
+		}
+
 		fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<Lit> {
 			slf.0.next().map(|lit| Lit(lit.into()))
 		}
@@ -724,9 +728,9 @@ mod pindakaas {
 			Self(Default::default())
 		}
 
-		fn new_var_range(&mut self, num_vars: usize) -> VarRange {
+		fn new_var_range(&mut self, num_vars: usize) -> PyResult<VarRange> {
 			let range = self.0.new_var_range(num_vars);
-			VarRange(range)
+			Ok(VarRange(range))
 		}
 
 		fn to_dimacs(&self) -> String {
@@ -766,7 +770,7 @@ mod pindakaas {
 		use pyo3::{exceptions::PyNotImplementedError, prelude::*, types::PyIterator};
 
 		use super::{encode_constraint_with_conditions, Result};
-		use crate::pindakaas::{ConstraintArg, Encoder, Lit};
+		use crate::pindakaas::{ConstraintArg, Encoder, Lit, VarRange};
 
 		#[pyclass(unsendable)]
 		#[derive(Debug, Default)]
@@ -835,9 +839,9 @@ mod pindakaas {
 				Self(Default::default())
 			}
 
-			fn new_var_range(&mut self, num_vars: usize) -> Result<(Lit, Lit)> {
+			fn new_var_range(&mut self, num_vars: usize) -> PyResult<VarRange> {
 				let range = self.0.new_var_range(num_vars);
-				Ok((Lit(range.start().into()), Lit(range.end().into())))
+				Ok(VarRange(range))
 			}
 
 			fn set_time_limit(&mut self, limit: Option<Duration>) -> Result {
@@ -899,10 +903,10 @@ mod pindakaas {
 				Self(Default::default())
 			}
 
-			fn new_var_range(&mut self, num_vars: usize) -> Result<(Lit, Lit)> {
+			fn new_var_range(&mut self, num_vars: usize) -> PyResult<VarRange> {
 				let mut guard = self.0.lock().unwrap();
 				let range = guard.new_var_range(num_vars);
-				Ok((Lit(range.start().into()), Lit(range.end().into())))
+				Ok(VarRange(range))
 			}
 
 			fn set_time_limit(&mut self, limit: Option<Duration>) {


### PR DESCRIPTION
Fixes #159 

The return of the `new_var_range` is a tuple with the start and end Lit, but for some ClauseDatabase/solvers the `VarRange` is still returned. This fixes it to always be that tuple, but shouldn't we just use the python level `VarRange` object?