### PR TITLE
chore: release

### DIFF
--- a/crates/pindakaas-cadical/CHANGELOG.md
+++ b/crates/pindakaas-cadical/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.2.0...pindakaas-cadical-v0.2.1) - 2025-09-30
+
+### Fixed
+
+- package unistd.h for windows release
+
 ## [0.2.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.1.0...pindakaas-cadical-v0.2.0) - 2025-09-25
 
 ### Added

--- a/crates/pindakaas-cadical/Cargo.toml
+++ b/crates/pindakaas-cadical/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-cadical"
 description = "build of the Cadical SAT solver for the pindakaas crate"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 
 include = [

--- a/crates/pindakaas/CHANGELOG.md
+++ b/crates/pindakaas/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.2.1...pindakaas-v0.2.2) - 2025-09-30
+
+### Other
+
+- updated the following local packages: pindakaas-cadical
+
 ## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.2.0...pindakaas-v0.2.1) - 2025-09-29
 
 ### Changed

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas"
 description = "Encoding Integer and Pseudo Boolean constraints into CNF"
-version = "0.2.1"
+version = "0.2.2"
 
 authors.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ libloading = { version = "0.8", optional = true }
 tracing = { workspace = true, optional = true }
 
 # Optional Solver Interfaces
-pindakaas-cadical = { version = "0.2.0", path = "../pindakaas-cadical", optional = true }
+pindakaas-cadical = { version = "0.2.1", path = "../pindakaas-cadical", optional = true }
 pindakaas-intel-sat = { version = "0.2.0", path = "../pindakaas-intel-sat", optional = true }
 pindakaas-kissat = { version = "0.2.0", path = "../pindakaas-kissat", optional = true }
 splr = { version = "0.17", optional = true }

--- a/crates/pyndakaas/CHANGELOG.md
+++ b/crates/pyndakaas/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.2.1...pyndakaas-v0.2.2) - 2025-09-30
+
+### Other
+
+- add pyproject metadata
+- updated the following local packages: pindakaas
+
 ## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.2.0...pyndakaas-v0.2.1) - 2025-09-29
 
 ### Fixed

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyndakaas"
 description = "Python bindings for the pindakaas crate"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 authors.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.14"
-pindakaas = { version = "0.2.1", path = "../pindakaas", features = ["kissat"] }
+pindakaas = { version = "0.2.2", path = "../pindakaas", features = ["kissat"] }
 pyo3 = "0.26.0"
 
 [lints]


### PR DESCRIPTION



## 🤖 New release

* `pindakaas-cadical`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `pyndakaas`: 0.2.1 -> 0.2.2
* `pindakaas`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `pindakaas-cadical`

<blockquote>

## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.2.0...pindakaas-cadical-v0.2.1) - 2025-09-30

### Fixed

- *(pindakaas-cadical)* package unistd.h for windows release
</blockquote>

## `pyndakaas`

<blockquote>

## [0.2.2](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.2.1...pyndakaas-v0.2.2) - 2025-09-30

### Other

- *(pyndakaas)* add pyproject metadata
</blockquote>

## `pindakaas`

<blockquote>

## [0.2.2](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.2.1...pindakaas-v0.2.2) - 2025-09-30

### Other

- updated the following local packages: pindakaas-cadical
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).