### PR TITLE
chore: release

### DIFF
--- a/crates/pindakaas-cadical/CHANGELOG.md
+++ b/crates/pindakaas-cadical/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.2.1...pindakaas-cadical-v0.3.0) - 2025-11-26
+
+### Added
+
+- update CaDiCaL to version 2.2.0
+
 ## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.2.0...pindakaas-cadical-v0.2.1) - 2025-09-30
 
 ### Fixed

--- a/crates/pindakaas-cadical/Cargo.toml
+++ b/crates/pindakaas-cadical/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-cadical"
 description = "build of the Cadical SAT solver for the pindakaas crate"
-version = "0.2.1"
+version = "0.3.0"
 license = "MIT"
 
 include = [

--- a/crates/pindakaas-kissat/CHANGELOG.md
+++ b/crates/pindakaas-kissat/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.0...pindakaas-kissat-v0.2.1) - 2025-11-26
+
+### Added
+
+- update Kissat to version 4.0.4
+
 ## [0.2.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.1.0...pindakaas-kissat-v0.2.0) - 2025-09-25
 
 ### Added

--- a/crates/pindakaas-kissat/Cargo.toml
+++ b/crates/pindakaas-kissat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-kissat"
 description = "build of the Kissat SAT solver for the pindakaas crate"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 
 build = "build.rs"

--- a/crates/pindakaas/CHANGELOG.md
+++ b/crates/pindakaas/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.2.3...pindakaas-v0.3.0) - 2025-11-26
+
+### Added
+
+- update CaDiCaL to version 2.2.0
+- updated Kissat to version 4.0.4
+
+### Changed
+
+- `Propagator::notify_assignments` is now named `Propagator::notify_assignment`.
+- `ProofTracer::add_derived_clause` now has an additional `witness` parameter.
+
+### Other
+
+- add citation to the documentation
+
 ## [0.2.3](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.2.2...pindakaas-v0.2.3) - 2025-11-04
 
 ### Fixed

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas"
 description = "Encoding Integer and Pseudo Boolean constraints into CNF"
-version = "0.2.3"
+version = "0.3.0"
 
 authors.workspace = true
 edition.workspace = true
@@ -27,9 +27,9 @@ libloading = { version = "0.8", optional = true }
 tracing = { workspace = true, optional = true }
 
 # Optional Solver Interfaces
-pindakaas-cadical = { version = "0.2.1", path = "../pindakaas-cadical", optional = true }
+pindakaas-cadical = { version = "0.3.0", path = "../pindakaas-cadical", optional = true }
 pindakaas-intel-sat = { version = "0.2.0", path = "../pindakaas-intel-sat", optional = true }
-pindakaas-kissat = { version = "0.2.0", path = "../pindakaas-kissat", optional = true }
+pindakaas-kissat = { version = "0.2.1", path = "../pindakaas-kissat", optional = true }
 splr = { version = "0.17", optional = true }
 
 [dev-dependencies]

--- a/crates/pyndakaas/CHANGELOG.md
+++ b/crates/pyndakaas/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.2.3...pyndakaas-v0.3.0) - 2025-11-26
+
+### Other
+
+- updated the following local packages: pindakaas
+- add citation to the documentation
+
 ## [0.2.3](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.2.2...pyndakaas-v0.2.3) - 2025-11-04
 
 ### Other

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyndakaas"
 description = "Python bindings for the pindakaas crate"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 
 authors.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.14"
-pindakaas = { version = "0.2.3", path = "../pindakaas", features = ["kissat"] }
+pindakaas = { version = "0.3.0", path = "../pindakaas", features = ["kissat"] }
 pyo3 = "0.26.0"
 
 [lints]


### PR DESCRIPTION



## 🤖 New release

* `pindakaas-cadical`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `pindakaas-kissat`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `pindakaas`: 0.2.3 -> 0.3.0 (⚠ API breaking changes)
* `pyndakaas`: 0.2.3 -> 0.2.4

### ⚠ `pindakaas-cadical` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CTracer.demote_clause in /tmp/.tmpXD6Weg/pindakaas/crates/pindakaas-cadical/src/lib.rs:136
  field CExternalPropagator.notify_assignment in /tmp/.tmpXD6Weg/pindakaas/crates/pindakaas-cadical/src/lib.rs:21

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field notify_assignments of struct CExternalPropagator, previously in file /tmp/.tmpGohr6a/pindakaas-cadical/src/lib.rs:21
```

### ⚠ `pindakaas` breaking changes

```text
--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_missing.ron

Failed in:
  method notify_assignments of trait Propagator, previously in file /tmp/.tmpGohr6a/pindakaas/src/solver/propagation.rs:126

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  ProofTracer::add_derived_clause now takes 6 instead of 5 parameters, in file /tmp/.tmpXD6Weg/pindakaas/crates/pindakaas/src/solver/cadical.rs:75
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pindakaas-cadical`

<blockquote>

## [0.3.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.2.1...pindakaas-cadical-v0.3.0) - 2025-11-26

### Added

- update CaDiCaL to version 2.2.0
</blockquote>

## `pindakaas-kissat`

<blockquote>

## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.0...pindakaas-kissat-v0.2.1) - 2025-11-26

### Added

- update Kissat to version 4.0.4
</blockquote>

## `pindakaas`

<blockquote>

## [0.3.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.2.3...pindakaas-v0.3.0) - 2025-11-26

### Added

- update CaDiCaL to version 2.2.0

### Other

- add citation to the documentation
</blockquote>

## `pyndakaas`

<blockquote>

## [0.2.4](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.2.3...pyndakaas-v0.2.4) - 2025-11-26

### Other

- add citation to the documentation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).