### PR TITLE
Set default propagation to None

### DIFF
--- a/crates/pindakaas/src/integer.rs
+++ b/crates/pindakaas/src/integer.rs
@@ -25,8 +25,8 @@ pub(crate) const GROUND_BINARY_AT_LB: bool = false;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Consistency {
-	None,
 	#[default]
+	None,
 	Bounds,
 	Domain,
 }


### PR DESCRIPTION
We have a feature which does bounds/domain-consistent propagation on the integer model, but in experiments, this did not help too much, so we should probably turn it off by default.

Another thing is that I'm slightly surprised that I set the default encoder to Totalizer for the Python interface for PB constraints, while on the Rust side it's the `StaticLinEncoder<Lin = AdderEncoder, ..>`. I'd be happy to change this, as the Adder seems our best all-round encoder for PB constraint. Some future benchmarks could revisit this choice (or give us a simple heuristic to choose between encoders).