### PR TITLE
chore: release

### DIFF
--- a/crates/pindakaas-cadical/CHANGELOG.md
+++ b/crates/pindakaas-cadical/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.3.0...pindakaas-cadical-v0.3.1) - 2026-02-10
+
+### Added
+
+- update CaDiCaL to version 3.0.0
+
 ## [0.3.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.2.1...pindakaas-cadical-v0.3.0) - 2025-11-26
 
 ### Added

--- a/crates/pindakaas-cadical/Cargo.toml
+++ b/crates/pindakaas-cadical/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-cadical"
 description = "build of the Cadical SAT solver for the pindakaas crate"
-version = "0.3.0"
+version = "0.3.1"
 license = "MIT"
 
 include = [

--- a/crates/pindakaas/CHANGELOG.md
+++ b/crates/pindakaas/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.3.0...pindakaas-v0.4.0) - 2026-02-10
+
+### Added
+
+- update CaDiCaL to version 3.0.0
+
+### Fixed
+
+- [**breaking**] replace broken `with_conditions` with `encode_implied`
+- propagation failure during linear simplication ([#184](https://github.com/pindakaashq/pindakaas/pull/184))
+
+### Other
+
+- [**breaking**] update default encoder choices
+- set default propagation consistency to None
+- remove unnecessary `use` ([#179](https://github.com/pindakaashq/pindakaas/pull/179))
+
 ## [0.3.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.2.3...pindakaas-v0.3.0) - 2025-11-26
 
 ### Added

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas"
 description = "Encoding Integer and Pseudo Boolean constraints into CNF"
-version = "0.3.0"
+version = "0.4.0"
 
 authors.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ libloading = { version = "0.8", optional = true }
 tracing = { workspace = true, optional = true }
 
 # Optional Solver Interfaces
-pindakaas-cadical = { version = "0.3.0", path = "../pindakaas-cadical", optional = true }
+pindakaas-cadical = { version = "0.3.1", path = "../pindakaas-cadical", optional = true }
 pindakaas-intel-sat = { version = "0.2.0", path = "../pindakaas-intel-sat", optional = true }
 pindakaas-kissat = { version = "0.2.1", path = "../pindakaas-kissat", optional = true }
 splr = { version = "0.17", optional = true }

--- a/crates/pyndakaas/CHANGELOG.md
+++ b/crates/pyndakaas/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.3.0...pyndakaas-v0.4.0) - 2026-02-10
+
+### Fixed
+
+- replace broken `with_conditions` with `encode_implied`
+
+### Other
+
+- [**breaking**] update default encoder choices
+
 ## [0.3.0](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.2.3...pyndakaas-v0.3.0) - 2025-11-26
 
 ### Other

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyndakaas"
 description = "Python bindings for the pindakaas crate"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 authors.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.14"
-pindakaas = { version = "0.3.0", path = "../pindakaas", features = ["kissat"] }
+pindakaas = { version = "0.4.0", path = "../pindakaas", features = ["kissat"] }
 pyo3 = "0.26.0"
 
 [lints]


### PR DESCRIPTION



## 🤖 New release

* `pindakaas-cadical`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `pindakaas`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `pyndakaas`: 0.3.0 -> 0.4.0

### ⚠ `pindakaas` breaking changes

```text
--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_missing.ron

Failed in:
  method with_conditions of trait ClauseDatabaseTools, previously in file /tmp/.tmpmSxQh7/pindakaas/src/lib.rs:426

--- failure trait_no_longer_dyn_compatible: trait no longer dyn compatible ---

Description:
Trait is no longer dyn compatible, which breaks `dyn Trait` usage.
        ref: https://doc.rust-lang.org/stable/reference/items/traits.html#object-safety
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_no_longer_dyn_compatible.ron

Failed in:
  trait Encoder in file /tmp/.tmpXUmeHa/pindakaas/crates/pindakaas/src/lib.rs:476
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pindakaas-cadical`

<blockquote>

## [0.3.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.3.0...pindakaas-cadical-v0.3.1) - 2026-02-10

### Added

- update CaDiCaL to version 3.0.0
</blockquote>

## `pindakaas`

<blockquote>

## [0.4.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.3.0...pindakaas-v0.4.0) - 2026-02-10

### Added

- update CaDiCaL to version 3.0.0

### Fixed

- Cadical::emitted_vars when zero variables have been created ([#186](https://github.com/pindakaashq/pindakaas/pull/186))
- replace broken `with_conditions` with `encode_implied`
- propagation failure during linear simplication ([#184](https://github.com/pindakaashq/pindakaas/pull/184))

### Other

- [**breaking**] update default encoder choices
- refactor!(pindakaas): set default propagation consistency to None
- remove unnecessary `use` ([#179](https://github.com/pindakaashq/pindakaas/pull/179))
</blockquote>

## `pyndakaas`

<blockquote>

## [0.4.0](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.3.0...pyndakaas-v0.4.0) - 2026-02-10

### Fixed

- Cadical::emitted_vars when zero variables have been created ([#186](https://github.com/pindakaashq/pindakaas/pull/186))
- replace broken `with_conditions` with `encode_implied`

### Other

- [**breaking**] update default encoder choices
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).