### PR TITLE
Fix adding unsat encoding with conditions

### DIFF
--- a/crates/pyndakaas/python/tests/test_encoding.py
+++ b/crates/pyndakaas/python/tests/test_encoding.py
@@ -110,6 +110,13 @@ def test_conditions():
     assert f.to_dimacs() == "p cnf 3 2\n3 1 2 0\n3 -1 -2 0\n"
 
 
+def test_add_unsat_with_conditions():
+    f = CNF()
+    x, y, p = f.new_vars(3)
+    f.add_encoding(x + y >= 5, conditions=[p])
+    assert f.to_dimacs() == "p cnf 3 1\n-3 0\n"
+
+
 def test_custom_db():
     f = CustomDB()
     assert f.new_var() == Lit.from_raw(1)

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -216,9 +216,10 @@ mod pindakaas {
 		}
 	}
 
+	/// Distinguish between unsat and other exceptions become `PyErr`s
 	enum EncodingError {
 		Unsatisfiable(::pindakaas::Unsatisfiable),
-		InvalidEncoder(String),
+		PyErr(PyErr),
 	}
 
 	impl From<::pindakaas::Unsatisfiable> for EncodingError {
@@ -227,12 +228,12 @@ mod pindakaas {
 		}
 	}
 
-	// Allow other `PyErr`s to become a wrapped exception
+	// Allow other `EncodingError`s to become a wrapped exception
 	impl From<EncodingError> for ErrWrapper {
 		fn from(err: EncodingError) -> Self {
 			match err {
 				EncodingError::Unsatisfiable(e) => e.into(),
-				EncodingError::InvalidEncoder(e) => ErrWrapper(InvalidEncoder::new_err(e)),
+				EncodingError::PyErr(e) => ErrWrapper(e),
 			}
 		}
 	}
@@ -248,9 +249,9 @@ mod pindakaas {
 		Db: ClauseDatabase,
 	{
 		let invalid_enc = |con_ty, enc| {
-			Err(EncodingError::InvalidEncoder(format!(
+			Err(EncodingError::PyErr(InvalidEncoder::new_err(format!(
 				"Unable to encode object of type `{con_ty}' using {enc:?}"
-			)))
+			))))
 		};
 
 		match con {

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -216,7 +216,7 @@ mod pindakaas {
 		}
 	}
 
-	/// Distinguish between unsat and other exceptions become `PyErr`s
+	/// Distinguish between unsat and other exceptions which become `PyErr`s
 	enum EncodingError {
 		Unsatisfiable(::pindakaas::Unsatisfiable),
 		PyErr(PyErr),

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -77,9 +77,12 @@ mod pindakaas {
 
 	#[pymodule_export]
 	use crate::InvalidEncoder;
-	use crate::Result;
 	#[pymodule_export]
 	use crate::Unsatisfiable;
+	use crate::{ErrWrapper, Result};
+
+	/// Add alias for BaseResult (since this is private to ::pindakaas)
+	type BaseResult = Result<(), ::pindakaas::Unsatisfiable>;
 
 	#[derive(FromPyObject)]
 	/// Argument capture for types that can become :class:`BoolLinExp`.
@@ -199,27 +202,55 @@ mod pindakaas {
 		Db: ClauseDatabase,
 	{
 		if conditions.is_empty() {
-			encode_constraint(db, con, enc)
+			Ok(encode_constraint(db, con, enc)?)
 		} else {
-			encode_constraint(
-				&mut db.with_conditions(conditions.into_iter().map(|l| l.0).collect()),
-				con,
-				enc,
-			)
+			let conditions = conditions.into_iter().map(|l| l.0).collect_vec();
+			let res = encode_constraint(&mut db.with_conditions(conditions.clone()), con, enc);
+			match res {
+				Err(EncodingError::Unsatisfiable(::pindakaas::Unsatisfiable)) => {
+					Ok(db.add_clause(conditions.into_iter().map(|l| !l))?)
+				}
+				Err(e) => Err(e.into()),
+				Ok(_) => Ok(()),
+			}
+		}
+	}
+
+	enum EncodingError {
+		Unsatisfiable(::pindakaas::Unsatisfiable),
+		InvalidEncoder(String),
+	}
+
+	impl From<::pindakaas::Unsatisfiable> for EncodingError {
+		fn from(value: ::pindakaas::Unsatisfiable) -> Self {
+			EncodingError::Unsatisfiable(value)
+		}
+	}
+
+	// Allow other `PyErr`s to become a wrapped exception
+	impl From<EncodingError> for ErrWrapper {
+		fn from(err: EncodingError) -> Self {
+			match err {
+				EncodingError::Unsatisfiable(e) => e.into(),
+				EncodingError::InvalidEncoder(e) => ErrWrapper(InvalidEncoder::new_err(e)),
+			}
 		}
 	}
 
 	/// Internal function to help with the encoding of a constraint given an
 	/// optional encoder.
-	fn encode_constraint<Db>(db: &mut Db, con: ConstraintArg, enc: Option<Encoder>) -> Result
+	fn encode_constraint<Db>(
+		db: &mut Db,
+		con: ConstraintArg,
+		enc: Option<Encoder>,
+	) -> Result<(), EncodingError>
 	where
 		Db: ClauseDatabase,
 	{
 		let invalid_enc = |con_ty, enc| {
-			Err(InvalidEncoder::new_err(format!(
+			Err(EncodingError::InvalidEncoder(format!(
 				"Unable to encode object of type `{con_ty}' using {enc:?}"
-			))
-			.into())
+			)))
 		};
 
 		match con {
@@ -271,10 +302,7 @@ mod pindakaas {
 	) -> Result {
 		struct PyDbWrapper<'a>(&'a Bound<'a, PyAny>);
 		impl ClauseDatabase for PyDbWrapper<'_> {
-			fn add_clause_from_slice(
-				&mut self,
-				clause: &[BaseLit],
-			) -> Result<(), pindakaas::Unsatisfiable> {
+			fn add_clause_from_slice(&mut self, clause: &[BaseLit]) -> BaseResult {
 				let clause = clause.iter().map(|&l| Lit(l)).collect_vec();
 				let res = self.0.call_method1("add_clause", (clause,));
 				match res {


### PR DESCRIPTION
Fixes #175.

It is a little tricky that when we have an Encoder on a conditional database, we still get Unsatisfiable. On the Rust side, this is not really incorrect, but tricky. At least this fix should be appropriate for the Python side, where it's definitely wrong.