### PR TITLE
fix: replace broken `with_conditions` with `encode_implied`

### DIFF
--- a/crates/pindakaas/src/bool_linear.rs
+++ b/crates/pindakaas/src/bool_linear.rs
@@ -36,8 +36,8 @@ use crate::{
 	},
 	propositional_logic::{Formula, TseitinEncoder},
 	sorted::{Sorted, SortedEncoder},
-	AsDynClauseDatabase, BoolVal, Checker, ClauseDatabase, ClauseDatabaseTools, Coeff, Encoder,
-	IntEncoding, Lit, Result, Unsatisfiable, Valuation, Var,
+	BoolVal, Checker, ClauseDatabase, ClauseDatabaseTools, Coeff, Encoder, IntEncoding, Lit,
+	Result, Unsatisfiable, Valuation, Var,
 };
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -304,7 +304,7 @@ impl AdderEncoder {
 	/// `output` can be either a literal, or a constant Boolean value.
 	fn sum_circuit<Db>(db: &mut Db, input: &[Lit], output: BoolVal) -> Result
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		match output {
 			BoolVal::Lit(sum) => match *input {
@@ -372,7 +372,7 @@ impl AdderEncoder {
 
 impl<Db> Encoder<Db, NormalizedBoolLinear> for AdderEncoder
 where
-	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	Db: ClauseDatabase + ?Sized,
 {
 	#[cfg_attr(
 		any(feature = "tracing", test),
@@ -416,7 +416,7 @@ where
 			match bucket[b].len() {
 				0 => {
 					if k[b] && lin.cmp == LimitComp::Equal {
-						return Err(Unsatisfiable);
+						return db.contradiction();
 					}
 				}
 				1 => {
@@ -512,20 +512,6 @@ where
 impl LinMarker for AdderEncoder {}
 
 impl BddEncoder {
-	/// Set whether to add consistency constraints on the intermediate integer
-	/// variables.
-	pub fn with_consistency(&mut self, b: bool) -> &mut Self {
-		self.add_consistency = b;
-		self
-	}
-
-	/// Set the largest domain size for which the intermediate integer variables
-	/// are encoded using order encoding.
-	pub fn with_cutoff(&mut self, c: Option<Coeff>) -> &mut Self {
-		self.cutoff = c;
-		self
-	}
-
 	fn bdd(
 		i: usize,
 		xs: &Vec<IntVarEnc>,
@@ -653,11 +639,25 @@ impl BddEncoder {
 		let _ = Self::bdd(0, xs, 0, &mut ws);
 		ws
 	}
+
+	/// Set whether to add consistency constraints on the intermediate integer
+	/// variables.
+	pub fn with_consistency(&mut self, b: bool) -> &mut Self {
+		self.add_consistency = b;
+		self
+	}
+
+	/// Set the largest domain size for which the intermediate integer variables
+	/// are encoded using order encoding.
+	pub fn with_cutoff(&mut self, c: Option<Coeff>) -> &mut Self {
+		self.cutoff = c;
+		self
+	}
 }
 
 impl<Db> Encoder<Db, NormalizedBoolLinear> for BddEncoder
 where
-	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	Db: ClauseDatabase + ?Sized,
 {
 	#[cfg_attr(
 		any(feature = "tracing", test),
@@ -702,7 +702,8 @@ where
 						self.add_consistency,
 					);
 					if y.dom.is_empty() {
-						return Err(Unsatisfiable);
+						db.contradiction()?;
+						unreachable!();
 					}
 					y.views = views
 						.into_iter()
@@ -742,7 +743,7 @@ impl BoolLinAggregator {
 	/// different encoding algorithms exist.
 	pub fn aggregate<Db>(&self, db: &mut Db, lin: &BoolLinear) -> Result<BoolLinVariant>
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		let mut k = lin.k;
 		// Aggregate multiple occurrences of the same
@@ -957,7 +958,8 @@ impl BoolLinAggregator {
 
 		// trivial case: constraint is unsatisfiable
 		if k < 0 {
-			return Err(Unsatisfiable);
+			db.contradiction()?;
+			unreachable!();
 		}
 		// trivial case: no literals can be activated
 		if k == 0 {
@@ -1062,7 +1064,8 @@ impl BoolLinAggregator {
 			}
 			LimitComp::Equal => {
 				if lhs_ub < k {
-					return Err(Unsatisfiable);
+					db.contradiction()?;
+					unreachable!();
 				}
 				if lhs_ub == k {
 					for part in partition {
@@ -1110,7 +1113,8 @@ impl BoolLinAggregator {
 		{
 			// trivial case: k cannot be made from the coefficients
 			if cmp == LimitComp::Equal && *k % *val != 0 {
-				return Err(Unsatisfiable);
+				db.contradiction()?;
+				unreachable!();
 			}
 
 			k = PosCoeff::new(*k / *val);
@@ -1340,7 +1344,7 @@ impl BoolLinExp {
 				.sum();
 			match constraint {
 				Some(Constraint::AtMostOne) => {
-					if sum != 0 && terms.iter().filter(|&(l, _)| sol.value(*l)).count() > 1 {
+					if sum != 0 && terms.iter().filter(|&&&(l, _)| sol.value(l)).count() > 1 {
 						return Err(Unsatisfiable);
 					}
 				}
@@ -1713,7 +1717,7 @@ impl From<LimitComp> for Comparator {
 // constraints
 impl<Db, Enc> Encoder<Db, Cardinality> for Enc
 where
-	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	Db: ClauseDatabase + ?Sized,
 	Enc: Encoder<Db, NormalizedBoolLinear> + LinMarker,
 {
 	fn encode(&self, db: &mut Db, con: &Cardinality) -> Result {
@@ -1731,6 +1735,22 @@ impl Display for LimitComp {
 }
 
 impl<Enc, Agg> LinearEncoder<Enc, Agg> {
+	/// Access the [`BoolLinAggregator`] used by this encoder.
+	pub fn linear_aggregator(&self) -> &Agg {
+		&self.agg
+	}
+
+	/// Create a new [`LinearEncoder`] with the given [`Encoder`] for
+	/// [`BoolLinVariant`]s and [`BoolLinAggregator`].
+	pub fn new(enc: Enc, agg: Agg) -> Self {
+		Self { enc, agg }
+	}
+
+	/// Access the [`Encoder`] for [`BoolLinVariant`]s used by this encoder.
+	pub fn variant_encoder(&self) -> &Enc {
+		&self.enc
+	}
+
 	/// Change the [`BoolLinAggregator`] used by this encoder.
 	pub fn with_linear_aggregator(&mut self, agg: Agg) -> &mut Self {
 		self.agg = agg;
@@ -1742,17 +1762,11 @@ impl<Enc, Agg> LinearEncoder<Enc, Agg> {
 		self.enc = enc;
 		self
 	}
-
-	/// Create a new [`LinearEncoder`] with the given [`Encoder`] for
-	/// [`BoolLinVariant`]s and [`BoolLinAggregator`].
-	pub fn new(enc: Enc, agg: Agg) -> Self {
-		Self { enc, agg }
-	}
 }
 
 impl<Db, Enc> Encoder<Db, BoolLinear> for LinearEncoder<Enc>
 where
-	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	Db: ClauseDatabase + ?Sized,
 	Enc: Encoder<Db, BoolLinVariant>,
 {
 	#[cfg_attr(
@@ -1988,7 +2002,7 @@ impl SwcEncoder {
 
 impl<Db> Encoder<Db, NormalizedBoolLinear> for SwcEncoder
 where
-	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	Db: ClauseDatabase + ?Sized,
 {
 	#[cfg_attr(
 		any(feature = "tracing", test),
@@ -2117,7 +2131,7 @@ impl TotalizerEncoder {
 
 impl<Db> Encoder<Db, NormalizedBoolLinear> for TotalizerEncoder
 where
-	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	Db: ClauseDatabase + ?Sized,
 {
 	#[cfg_attr(
 		any(feature = "tracing", test),
@@ -2367,7 +2381,6 @@ mod tests {
 					let a = cnf.new_lit();
 					let b = cnf.new_lit();
 					let res = $encoder.encode(
-						// &mut cnf.with_conditions(vec![!a]),
 						&mut cnf,
 						&NormalizedBoolLinear {
 							terms: construct_terms(&[(a, 3), (b, 9)]),

--- a/crates/pindakaas/src/cardinality.rs
+++ b/crates/pindakaas/src/cardinality.rs
@@ -10,7 +10,7 @@ use crate::{
 	cardinality_one::CardinalityOne,
 	integer::IntVarEnc,
 	sorted::{Sorted, SortedEncoder},
-	AsDynClauseDatabase, Checker, ClauseDatabase, Coeff, Encoder, Lit, Result, Valuation,
+	Checker, ClauseDatabase, Coeff, Encoder, Lit, Result, Valuation,
 };
 
 // local marker trait, to ensure the previous definition only applies within
@@ -123,7 +123,7 @@ impl Default for SortingNetworkEncoder {
 
 impl<Db> Encoder<Db, Cardinality> for SortingNetworkEncoder
 where
-	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	Db: ClauseDatabase + ?Sized,
 {
 	#[cfg_attr(
 		any(feature = "tracing", test),

--- a/crates/pindakaas/src/integer.rs
+++ b/crates/pindakaas/src/integer.rs
@@ -15,8 +15,8 @@ use crate::{
 	bool_linear::{BoolLinExp, LimitComp, Part, PosCoeff},
 	helpers::{as_binary, is_powers_of_two, new_named_lit, unsigned_binary_range_ub},
 	propositional_logic::{Formula, TseitinEncoder},
-	AsDynClauseDatabase, BoolVal, Checker, ClauseDatabase, ClauseDatabaseTools, Coeff, Encoder,
-	Lit, Result, Unsatisfiable, Valuation,
+	BoolVal, Checker, ClauseDatabase, ClauseDatabaseTools, Coeff, Encoder, Lit, Result,
+	Unsatisfiable, Valuation,
 };
 
 const COUPLE_DOM_PART_TO_ORD: bool = false;
@@ -277,6 +277,58 @@ where
 		.collect()
 }
 
+impl From<&IntVarBin> for BoolLinExp {
+	fn from(value: &IntVarBin) -> Self {
+		let mut k = 1;
+		let terms = value
+			.xs
+			.iter()
+			.map(|x| {
+				let term = (*x, k);
+				k *= 2;
+				term
+			})
+			.collect_vec();
+		let lin_exp =
+			BoolLinExp::default().add_bounded_log_encoding(terms.as_slice(), value.lb, value.ub);
+		if GROUND_BINARY_AT_LB {
+			lin_exp.add_constant(value.lb)
+		} else {
+			lin_exp
+		}
+	}
+}
+
+impl From<&IntVarEnc> for BoolLinExp {
+	fn from(value: &IntVarEnc) -> Self {
+		match value {
+			IntVarEnc::Ord(o) => o.into(),
+			IntVarEnc::Bin(b) => b.into(),
+			&IntVarEnc::Const(c) => c.into(),
+		}
+	}
+}
+
+impl From<&IntVarOrd> for BoolLinExp {
+	fn from(value: &IntVarOrd) -> Self {
+		let mut acc = value.lb();
+		let mut dom_it = value.dom.iter().flatten();
+		let _ = dom_it.next();
+		BoolLinExp::default()
+			.add_chain(
+				&dom_it
+					.zip_eq(&value.xs)
+					.map(|(iv, lit)| {
+						let v = iv - acc;
+						acc += v;
+						(*lit, v)
+					})
+					.collect_vec(),
+			)
+			.add_constant(value.lb())
+	}
+}
+
 impl Checker for ImplicationChainConstraint {
 	fn check<F: Valuation + ?Sized>(&self, sol: &F) -> Result {
 		for (a, b) in self.lits.iter().copied().tuple_windows() {
@@ -301,6 +353,11 @@ impl ImplicationChainEncoder {
 }
 
 impl IntVar {
+	/// Checks for failure i.e. empty domain
+	fn check(&self) -> Result {
+		(!self.dom.is_empty()).then_some(()).ok_or(Unsatisfiable)
+	}
+
 	fn encode<Db>(
 		&self,
 		db: &mut Db,
@@ -308,7 +365,7 @@ impl IntVar {
 		prefer_order: bool,
 	) -> IntVarEnc
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		if self.size() == 1 {
 			IntVarEnc::Const(*self.dom.lower_bound().unwrap())
@@ -358,11 +415,6 @@ impl IntVar {
 	fn ge(&mut self, bound: Coeff) -> Result {
 		self.dom = self.dom.intersect(&RangeList::from(bound..=Coeff::MAX));
 		self.check()
-	}
-
-	/// Checks for failure i.e. empty domain
-	fn check(&self) -> Result {
-		(!self.dom.is_empty()).then_some(()).ok_or(Unsatisfiable)
 	}
 
 	pub(crate) fn lb(&self, c: Coeff) -> Coeff {
@@ -419,7 +471,7 @@ impl Display for IntVar {
 impl IntVarBin {
 	pub(crate) fn add<Db>(&self, db: &mut Db, encoder: &TernLeEncoder, y: Coeff) -> Result<Self>
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		if y == 0 {
 			Ok(self.clone())
@@ -453,7 +505,7 @@ impl IntVarBin {
 
 	pub(crate) fn consistent<Db>(&self, db: &mut Db) -> Result
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		let encoder = TernLeEncoder::default();
 		if !GROUND_BINARY_AT_LB {
@@ -606,7 +658,7 @@ impl IntVarEnc {
 		// enc: &'a mut dyn Encoder<Db, TernLeConstraint<'a, Db, C>>,
 	) -> Result<IntVarEnc>
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		let comp_lb = self.lb() + y.lb();
 		let lb = max(lb.unwrap_or(comp_lb), comp_lb);
@@ -675,7 +727,7 @@ impl IntVarEnc {
 
 	pub(crate) fn consistent<Db>(&self, db: &mut Db) -> Result
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		match self {
 			IntVarEnc::Ord(o) => o.consistent(db),
@@ -704,7 +756,7 @@ impl IntVarEnc {
 	/// ∑ xs ≦ ∑ ys
 	pub(crate) fn from_part<Db>(db: &mut Db, xs: &Part, ub: PosCoeff, lbl: String) -> Vec<Self>
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		match xs {
 			Part::Amo(terms) => {
@@ -1205,58 +1257,6 @@ impl Display for Lin {
 	}
 }
 
-impl From<&IntVarBin> for BoolLinExp {
-	fn from(value: &IntVarBin) -> Self {
-		let mut k = 1;
-		let terms = value
-			.xs
-			.iter()
-			.map(|x| {
-				let term = (*x, k);
-				k *= 2;
-				term
-			})
-			.collect_vec();
-		let lin_exp =
-			BoolLinExp::default().add_bounded_log_encoding(terms.as_slice(), value.lb, value.ub);
-		if GROUND_BINARY_AT_LB {
-			lin_exp.add_constant(value.lb)
-		} else {
-			lin_exp
-		}
-	}
-}
-
-impl From<&IntVarEnc> for BoolLinExp {
-	fn from(value: &IntVarEnc) -> Self {
-		match value {
-			IntVarEnc::Ord(o) => o.into(),
-			IntVarEnc::Bin(b) => b.into(),
-			&IntVarEnc::Const(c) => c.into(),
-		}
-	}
-}
-
-impl From<&IntVarOrd> for BoolLinExp {
-	fn from(value: &IntVarOrd) -> Self {
-		let mut acc = value.lb();
-		let mut dom_it = value.dom.iter().flatten();
-		let _ = dom_it.next();
-		BoolLinExp::default()
-			.add_chain(
-				&dom_it
-					.zip_eq(&value.xs)
-					.map(|(iv, lit)| {
-						let v = iv - acc;
-						acc += v;
-						(*lit, v)
-					})
-					.collect_vec(),
-			)
-			.add_constant(value.lb())
-	}
-}
-
 impl Model {
 	pub(crate) fn add_int_var_enc(&mut self, x: IntVarEnc) -> IntVar {
 		let var = self.new_var(x.dom(), false);
@@ -1266,7 +1266,7 @@ impl Model {
 
 	pub(crate) fn encode<Db>(&mut self, db: &mut Db, cutoff: Option<Coeff>) -> Result
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		let mut all_views = FxHashMap::default();
 		for con in &self.cons {
@@ -1400,7 +1400,7 @@ impl Display for TernLeConstraint<'_> {
 
 impl<Db> Encoder<Db, TernLeConstraint<'_>> for TernLeEncoder
 where
-	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	Db: ClauseDatabase + ?Sized,
 {
 	#[cfg_attr(
 		any(feature = "tracing", test),
@@ -1452,7 +1452,8 @@ where
 				if tern.check(&|_| unreachable!()).is_ok() {
 					Ok(())
 				} else {
-					Err(Unsatisfiable)
+					db.contradiction()?;
+					unreachable!();
 				}
 			}
 			(IntVarEnc::Const(x_con), IntVarEnc::Const(y_con), IntVarEnc::Bin(z_bin)) => {
@@ -1661,7 +1662,7 @@ pub(crate) mod tests {
 		helpers::tests::{assert_solutions, expect_file, make_valuation},
 		integer::{IntVarBin, IntVarEnc, IntVarOrd, TernLeConstraint, TernLeEncoder},
 		propositional_logic::Formula,
-		AsDynClauseDatabase, BoolVal, ClauseDatabase, Cnf, Coeff, Encoder, Lit, Var, VarRange,
+		BoolVal, ClauseDatabase, Cnf, Coeff, Encoder, Lit, Var, VarRange,
 	};
 
 	#[test]
@@ -1853,7 +1854,7 @@ pub(crate) mod tests {
 
 	fn get_bin_x<Db>(db: &mut Db, lb: Coeff, ub: Coeff, consistent: bool, lbl: String) -> IntVarEnc
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		let x = IntVarBin::from_bounds(db, lb, ub, lbl);
 		if consistent {

--- a/crates/pindakaas/src/lib.rs
+++ b/crates/pindakaas/src/lib.rs
@@ -345,6 +345,16 @@ pub trait ClauseDatabaseTools: ClauseDatabase {
 		}
 	}
 
+	/// Encoder helper that signals a contradiction has been detected in the
+	/// constraint being encoded.
+	///
+	/// This will add an empty clause to the clause database.
+	fn contradiction(&mut self) -> Result {
+		let err = self.add_clause_from_slice(&[]);
+		debug_assert_eq!(err, Err(Unsatisfiable));
+		err
+	}
+
 	/// Encode a constraint using the provided encoder.
 	fn encode<C, E>(&mut self, constraint: &C, encoder: &E) -> Result
 	where
@@ -352,6 +362,18 @@ pub trait ClauseDatabaseTools: ClauseDatabase {
 		E: Encoder<Self, C> + ?Sized,
 	{
 		encoder.encode(self, constraint)
+	}
+
+	/// Encode an implied constraint of the form `conditions -> constraint`.
+	///
+	/// This is a thin convenience wrapper around
+	/// [`Encoder::encode_implied`].
+	fn encode_implied<C, E>(&mut self, conditions: &[Lit], constraint: &C, encoder: &E) -> Result
+	where
+		C: ?Sized,
+		E: Encoder<Self, C> + ?Sized + for<'a> Encoder<dyn ClauseDatabase + 'a, C>,
+	{
+		encoder.encode_implied(self, conditions, constraint)
 	}
 
 	/// Create a new Boolean variable in the form of a positive literal.
@@ -417,42 +439,6 @@ pub trait ClauseDatabaseTools: ClauseDatabase {
 		let range = self.new_var_range(T::num_items());
 		range.collect_tuple().unwrap()
 	}
-
-	/// Create a [`ClauseDatabase`] wrapper that adds the given conditions to
-	/// each clause that it adds to the wrapped database.
-	///
-	/// Note that the wrapped database type itself implements the
-	/// [`ClauseDatabase`] trait.
-	fn with_conditions(&mut self, conditions: Vec<Lit>) -> impl ClauseDatabase + '_
-	where
-		Self: AsDynClauseDatabase,
-	{
-		struct ConditionalDatabase<'a> {
-			db: &'a mut dyn ClauseDatabase,
-			conditions: Vec<Lit>,
-		}
-
-		impl ClauseDatabase for ConditionalDatabase<'_> {
-			fn add_clause_from_slice(&mut self, clause: &[Lit]) -> Result {
-				let chain = self
-					.conditions
-					.iter()
-					.copied()
-					.chain(clause.iter().copied())
-					.collect_vec();
-				self.db.add_clause_from_slice(&chain)
-			}
-
-			fn new_var_range(&mut self, len: usize) -> VarRange {
-				self.db.new_var_range(len)
-			}
-		}
-
-		ConditionalDatabase {
-			db: self.as_mut_dyn(),
-			conditions,
-		}
-	}
 }
 
 /// A representation for Boolean formulas in conjunctive normal form.
@@ -490,6 +476,74 @@ enum Dimacs {
 pub trait Encoder<Db: ClauseDatabase + ?Sized, Constraint: ?Sized> {
 	/// Encode the constraint into the given clausal database.
 	fn encode(&self, db: &mut Db, con: &Constraint) -> Result;
+
+	/// Encode the implied constraint `conditions -> constraint`.
+	///
+	/// Clauses emitted while encoding are guarded with the condition literals.
+	/// If encoding returns [`Unsatisfiable`], the conditions are forced to be
+	/// false.
+	fn encode_implied(&self, db: &mut Db, conditions: &[Lit], con: &Constraint) -> Result
+	where
+		Self: for<'a> Encoder<dyn ClauseDatabase + 'a, Constraint>,
+	{
+		if conditions.is_empty() {
+			return self.encode(db, con);
+		}
+
+		struct ClauseBuffer<'a, Db: ClauseDatabase + ?Sized> {
+			db: &'a mut Db,
+			lits: Vec<Lit>,
+			size: Vec<usize>,
+		}
+
+		impl<Db: ClauseDatabase + ?Sized> ClauseDatabase for ClauseBuffer<'_, Db> {
+			fn add_clause_from_slice(&mut self, clause: &[Lit]) -> Result {
+				let start = self.lits.len();
+				self.lits.extend_from_slice(clause);
+				let len = self.lits.len() - start;
+				self.size.push(len);
+				if len == 0 {
+					Err(Unsatisfiable)
+				} else {
+					Ok(())
+				}
+			}
+
+			fn new_var_range(&mut self, len: usize) -> VarRange {
+				self.db.new_var_range(len)
+			}
+		}
+
+		let (result, lits, sizes) = {
+			let mut cdb = ClauseBuffer {
+				db,
+				lits: Vec::new(),
+				size: Vec::new(),
+			};
+			let result = {
+				let cdb_dyn: &mut (dyn ClauseDatabase + '_) = &mut cdb;
+				self.encode(cdb_dyn, con)
+			};
+			(result, cdb.lits, cdb.size)
+		};
+
+		let conditions: Vec<_> = conditions.iter().map(|&l| !l).collect();
+		let (lits, sizes) = match result {
+			Ok(()) => (lits, sizes),
+			Err(Unsatisfiable) => return db.add_clause_from_slice(&conditions),
+		};
+
+		let mut index = 0;
+		let mut clause = Vec::with_capacity(conditions.len());
+		for size in sizes {
+			clause.clear();
+			clause.extend_from_slice(&conditions);
+			clause.extend_from_slice(&lits[index..index + size]);
+			db.add_clause_from_slice(&clause)?;
+			index += size;
+		}
+		Ok(())
+	}
 }
 
 /// IntEncoding is a enumerated type use to represent an Boolean encoding of a
@@ -859,6 +913,11 @@ impl Cnf {
 		self.size.len()
 	}
 
+	/// Returns the number of variables in the formula.
+	pub fn num_vars(&self) -> usize {
+		self.nvar.num_emitted_vars()
+	}
+
 	/// Store CNF formula at given path in DIMACS format
 	///
 	/// File will optionally be prefaced by a given comment
@@ -870,11 +929,6 @@ impl Cnf {
 			}
 		}
 		write!(file, "{self}")
-	}
-
-	/// Returns the number of variables in the formula.
-	pub fn num_vars(&self) -> usize {
-		self.nvar.num_emitted_vars()
 	}
 
 	/// Returns the range of variables emitted to be used by this formula.
@@ -1357,16 +1411,6 @@ impl Wcnf {
 		Ok(())
 	}
 
-	/// Returns the number of clauses in the formula.
-	pub fn num_clauses(&self) -> usize {
-		self.cnf.num_clauses()
-	}
-
-	/// Returns the number of variables in the formula.
-	pub fn num_vars(&self) -> usize {
-		self.cnf.num_vars()
-	}
-
 	/// Read a WCNF formula from a file formatted in the (W)DIMACS WCNF format
 	pub fn from_file(path: &Path) -> Result<Self, io::Error> {
 		match parse_dimacs_file::<true>(path)? {
@@ -1383,6 +1427,16 @@ impl Wcnf {
 	/// Returns the number of literals in the formula.
 	pub fn literals(&self) -> usize {
 		self.cnf.literals()
+	}
+
+	/// Returns the number of clauses in the formula.
+	pub fn num_clauses(&self) -> usize {
+		self.cnf.num_clauses()
+	}
+
+	/// Returns the number of variables in the formula.
+	pub fn num_vars(&self) -> usize {
+		self.cnf.num_vars()
 	}
 
 	/// Store WCNF formula at given path in WDIMACS format

--- a/crates/pindakaas/src/propositional_logic.rs
+++ b/crates/pindakaas/src/propositional_logic.rs
@@ -14,10 +14,7 @@ use std::{
 use itertools::{Itertools, Position};
 use rustc_hash::FxHashSet;
 
-use crate::{
-	AsDynClauseDatabase, BoolVal, ClauseDatabase, ClauseDatabaseTools, Cnf, Encoder, Lit, Result,
-	Unsatisfiable,
-};
+use crate::{BoolVal, ClauseDatabase, ClauseDatabaseTools, Cnf, Encoder, Lit, Result};
 
 /// A propositional logic formula
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -686,11 +683,14 @@ impl<Base> Not for Formula<Base> {
 
 impl<Db> Encoder<Db, Formula<BoolVal>> for TseitinEncoder
 where
-	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	Db: ClauseDatabase + ?Sized,
 {
 	fn encode(&self, db: &mut Db, con: &Formula<BoolVal>) -> Result {
 		match con.clone().resolve() {
-			Err(false) => Err(Unsatisfiable),
+			Err(false) => {
+				db.contradiction()?;
+				unreachable!();
+			}
 			Err(true) => Ok(()),
 			Ok(con) => self.encode(db, &con),
 		}
@@ -699,7 +699,7 @@ where
 
 impl<Db> Encoder<Db, Formula<Lit>> for TseitinEncoder
 where
-	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	Db: ClauseDatabase + ?Sized,
 {
 	fn encode(&self, db: &mut Db, f: &Formula<Lit>) -> Result {
 		match f {
@@ -721,14 +721,10 @@ where
 				}
 				Formula::IfThenElse { cond, then, els } => {
 					let name = cond.bind(db, None)?;
-					{
-						let mut cdb = db.with_conditions(vec![!name]);
-						let neg_then: Formula<Lit> = !*then.clone();
-						self.encode(&mut cdb, &neg_then)?;
-					}
-					let mut cdb = db.with_conditions(vec![name]);
+					let neg_then: Formula<Lit> = !*then.clone();
+					db.encode_implied(&[name], &neg_then, self)?;
 					let neg_els: Formula<Lit> = !*els.clone();
-					self.encode(&mut cdb, &neg_els)
+					db.encode_implied(&[!name], &neg_els, self)
 				}
 				Formula::Equiv(sub) if sub.len() == 2 => {
 					self.encode(db, &Formula::Xor(sub.clone()))
@@ -753,7 +749,8 @@ where
 			}
 			Formula::Or(sub) => {
 				if sub.is_empty() {
-					return Err(Unsatisfiable);
+					db.contradiction()?;
+					unreachable!();
 				}
 				let lits = sub
 					.iter()
@@ -763,8 +760,7 @@ where
 			}
 			Formula::Implies(left, right) => {
 				let x = left.bind(db, None)?;
-				let mut cdb = db.with_conditions(vec![!x]);
-				self.encode(&mut cdb, right.as_ref())
+				db.encode_implied(&[x], right.as_ref(), self)
 			}
 			Formula::Equiv(sub) => {
 				match sub.len() {
@@ -786,7 +782,10 @@ where
 				Ok(())
 			}
 			Formula::Xor(sub) => match sub.len() {
-				0 => Err(Unsatisfiable),
+				0 => {
+					db.contradiction()?;
+					unreachable!()
+				}
 				1 => self.encode(db, &sub[0]),
 				_ => {
 					let mut sub = sub.clone();
@@ -802,12 +801,8 @@ where
 			},
 			Formula::IfThenElse { cond, then, els } => {
 				let name = cond.bind(db, None)?;
-				{
-					let mut cdb = db.with_conditions(vec![!name]);
-					self.encode(&mut cdb, then.as_ref())?;
-				}
-				let mut cdb = db.with_conditions(vec![name]);
-				self.encode(&mut cdb, els.as_ref())
+				db.encode_implied(&[name], then.as_ref(), self)?;
+				db.encode_implied(&[!name], els.as_ref(), self)
 			}
 		}
 	}
@@ -820,7 +815,8 @@ mod tests {
 	use crate::{
 		helpers::tests::{assert_encoding, assert_solutions, expect_file},
 		propositional_logic::{Formula, TseitinEncoder},
-		ClauseDatabase, ClauseDatabaseTools, Cnf, Encoder,
+		solver::{cadical::Cadical, SolveResult, Solver},
+		ClauseDatabase, ClauseDatabaseTools, Cnf, Encoder, Valuation,
 	};
 
 	#[test]
@@ -1176,5 +1172,23 @@ mod tests {
 			[a, b, c, d],
 			&expect_file!["propositional_logic/encode_prop_xor_neg3.sol"],
 		);
+	}
+
+	#[test]
+	fn issue_175_implied_unsat() {
+		let mut cnf = Cadical::default();
+		let a = cnf.new_lit();
+		TseitinEncoder
+			.encode_implied(
+				&mut cnf,
+				&[a],
+				&Formula::Implies(Box::new(Formula::Atom(a)), Box::new(Formula::Xor(vec![]))),
+			)
+			.unwrap();
+
+		let SolveResult::Satisfied(sol) = cnf.solve() else {
+			panic!("Expected a solution");
+		};
+		assert!(!sol.value(a));
 	}
 }

--- a/crates/pindakaas/src/solver/ipasir.rs
+++ b/crates/pindakaas/src/solver/ipasir.rs
@@ -96,9 +96,9 @@ pub(crate) type IpasirLearnCb = Box<dyn FnMut(*const i32)>;
 /// If a type implements this trait and [`AccessIpasirSolver`], then
 /// [`Solver`] is implemented automatically.
 pub trait IpasirSolverMethods {
+	const IPASIR_ADD: unsafe extern "C" fn(slv: *mut c_void, lit_or_zero: i32);
 	const IPASIR_INIT: unsafe extern "C" fn() -> *mut c_void;
 	const IPASIR_RELEASE: unsafe extern "C" fn(slv: *mut c_void);
-	const IPASIR_ADD: unsafe extern "C" fn(slv: *mut c_void, lit_or_zero: i32);
 	const IPASIR_SOLVE: unsafe extern "C" fn(slv: *mut c_void) -> c_int;
 	const IPASIR_VAL: unsafe extern "C" fn(slv: *mut c_void, lit: i32) -> i32;
 }

--- a/crates/pindakaas/src/solver/ipasir/user_propagation.rs
+++ b/crates/pindakaas/src/solver/ipasir/user_propagation.rs
@@ -69,6 +69,14 @@ trait IpasirPropagatorStorage {
 	/// Returns whether a propagator is currently connected.
 	fn has_propagator(&self) -> bool;
 
+	/// Resets the persistent listener storage, dropping the connected listener
+	/// (if any).
+	fn reset_persistent_listener(&mut self);
+
+	/// Resets the propagator storage, dropping the connected propagator (if
+	/// any).
+	fn reset_propagator(&mut self);
+
 	/// Stores a new persistent listener in the storage, returning the
 	/// [`CFixedAssignmentListener`] that can be passed to the solver's C
 	/// methods to register the listener.
@@ -84,14 +92,6 @@ trait IpasirPropagatorStorage {
 		&mut self,
 		propagator: Rc<RefCell<P>>,
 	) -> CExternalPropagator;
-
-	/// Resets the persistent listener storage, dropping the connected listener
-	/// (if any).
-	fn reset_persistent_listener(&mut self);
-
-	/// Resets the propagator storage, dropping the connected propagator (if
-	/// any).
-	fn reset_propagator(&mut self);
 }
 
 /// Helping wrapper struct to provide [`ExtendedSolvingActions`] to propagators

--- a/crates/pindakaas/src/solver/propagation.rs
+++ b/crates/pindakaas/src/solver/propagation.rs
@@ -117,23 +117,21 @@ pub trait PersistentAssignmentNotifier: Solver {
 /// Trait implemented to provide external propagation for [`Solver`]s
 /// implementing the [`ExternalPropagation`] trait.
 pub trait Propagator {
-	/// Method called to notify the propagator about assignments of literals
-	/// concerning observed variables.
-	///
-	/// The notification is not necessarily eager. It usually happens before the
-	/// call of propagator callbacks and when a driving clause is leading to an
-	/// assignment.
-	fn notify_assignment(&mut self, lits: &[Lit]) {
-		let _ = lits;
+	/// Method to ask whether there is an external clause to add to the solver.
+	fn add_external_clause(
+		&mut self,
+		slv: &mut dyn SolvingActions,
+	) -> Option<(Vec<Lit>, ClausePersistence)> {
+		let _ = slv;
+		None
 	}
-	/// Method called to notify the propagator about a new decision level.
-	fn notify_new_decision_level(&mut self) {}
 
-	/// Method called to notify the propagator about a backtrack to an earlier
-	/// decision level.
-	fn notify_backtrack(&mut self, new_level: usize, restart: bool) {
-		let _ = new_level;
-		let _ = restart;
+	/// Ask the external propagator for the reason clause of a previous external
+	/// propagation step (done by [`Propagator::propagate`]). The clause must
+	/// contain the propagated literal.
+	fn add_reason_clause(&mut self, propagated_lit: Lit) -> Vec<Lit> {
+		let _ = propagated_lit;
+		Vec::new()
 	}
 
 	/// Method called to check the found complete solution (after solution
@@ -155,28 +153,30 @@ pub trait Propagator {
 		SearchDecision::Free
 	}
 
+	/// Method called to notify the propagator about assignments of literals
+	/// concerning observed variables.
+	///
+	/// The notification is not necessarily eager. It usually happens before the
+	/// call of propagator callbacks and when a driving clause is leading to an
+	/// assignment.
+	fn notify_assignment(&mut self, lits: &[Lit]) {
+		let _ = lits;
+	}
+
+	/// Method called to notify the propagator about a backtrack to an earlier
+	/// decision level.
+	fn notify_backtrack(&mut self, new_level: usize, restart: bool) {
+		let _ = new_level;
+		let _ = restart;
+	}
+	/// Method called to notify the propagator about a new decision level.
+	fn notify_new_decision_level(&mut self) {}
+
 	/// Method to ask the propagator if there is an propagation to make under
 	/// the current assignment. It returns queue of literals to be propagated
 	/// in order, if an empty queue is returned it indicates that there is no
 	/// propagation under the current assignment.
 	fn propagate(&mut self, slv: &mut dyn SolvingActions) -> Option<Lit> {
-		let _ = slv;
-		None
-	}
-
-	/// Ask the external propagator for the reason clause of a previous external
-	/// propagation step (done by [`Propagator::propagate`]). The clause must
-	/// contain the propagated literal.
-	fn add_reason_clause(&mut self, propagated_lit: Lit) -> Vec<Lit> {
-		let _ = propagated_lit;
-		Vec::new()
-	}
-
-	/// Method to ask whether there is an external clause to add to the solver.
-	fn add_external_clause(
-		&mut self,
-		slv: &mut dyn SolvingActions,
-	) -> Option<(Vec<Lit>, ClausePersistence)> {
 		let _ = slv;
 		None
 	}

--- a/crates/pindakaas/src/sorted.rs
+++ b/crates/pindakaas/src/sorted.rs
@@ -7,8 +7,7 @@ use crate::{
 	bool_linear::{BoolLinExp, LimitComp},
 	integer::{IntVarEnc, IntVarOrd, TernLeConstraint, TernLeEncoder},
 	propositional_logic::{Formula, TseitinEncoder},
-	AsDynClauseDatabase, Checker, ClauseDatabase, Coeff, Encoder, Lit, Result, Unsatisfiable,
-	Valuation,
+	Checker, ClauseDatabase, Coeff, Encoder, Lit, Result, Unsatisfiable, Valuation,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -86,7 +85,7 @@ impl SortedEncoder {
 		c: Coeff,
 	) -> Result
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		let cmp = self.overwrite_recursive_cmp.as_ref().unwrap_or(cmp);
 		let c1 = c;
@@ -124,7 +123,7 @@ impl SortedEncoder {
 		_lvl: usize,
 	) -> Result
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		let (a, b, c) = (x1.ub(), x2.ub(), y.ub());
 		let strat = if let SortedStrategy::Mixed(lambda) = &self.strategy {
@@ -202,7 +201,7 @@ impl SortedEncoder {
 
 	fn next_int_var<Db>(&self, db: &mut Db, ub: Coeff, lbl: String) -> IntVarEnc
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		// TODO We always have the view x>=1 <-> y>=1, which is now realized using equiv
 		if ub == 0 {
@@ -226,7 +225,7 @@ impl SortedEncoder {
 		y: &IntVarEnc,
 	) -> Result
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		// we let x2 take the place of z_ceil, so we need to add 1 to both sides
 		let x2 = x2.add(
@@ -256,7 +255,7 @@ impl SortedEncoder {
 		_lvl: usize,
 	) -> Option<IntVarEnc>
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		match xs {
 			[] => None,
@@ -278,7 +277,7 @@ impl SortedEncoder {
 		_lvl: usize,
 	) -> Result
 	where
-		Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+		Db: ClauseDatabase + ?Sized,
 	{
 		let (n, m) = (xs.len(), y.ub());
 		let direct = false;
@@ -401,7 +400,7 @@ impl Default for SortedEncoder {
 	}
 }
 
-impl<Db: ClauseDatabase + AsDynClauseDatabase + ?Sized> Encoder<Db, Sorted<'_>> for SortedEncoder {
+impl<Db: ClauseDatabase + ?Sized> Encoder<Db, Sorted<'_>> for SortedEncoder {
 	fn encode(&self, db: &mut Db, sorted: &Sorted) -> Result {
 		let xs = sorted
 			.xs
@@ -423,7 +422,7 @@ impl<Db: ClauseDatabase + AsDynClauseDatabase + ?Sized> Encoder<Db, Sorted<'_>> 
 
 impl<Db> Encoder<Db, TernLeConstraint<'_>> for SortedEncoder
 where
-	Db: ClauseDatabase + AsDynClauseDatabase + ?Sized,
+	Db: ClauseDatabase + ?Sized,
 {
 	fn encode(&self, db: &mut Db, tern: &TernLeConstraint) -> Result {
 		let TernLeConstraint { x, y, cmp, z } = tern;

--- a/crates/pyndakaas/python/tests/test_encoding.py
+++ b/crates/pyndakaas/python/tests/test_encoding.py
@@ -22,7 +22,10 @@ class CustomDB(ClauseDatabase):
         self.next_var = 1
 
     def add_clause(self, clause: Iterable[Lit]):
-        self.clauses.append([int(lit) for lit in clause])
+        clause = [int(lit) for lit in clause]
+        if clause == []:
+            raise Unsatisfiable()
+        self.clauses.append(clause)
 
     def new_var_range(self, n: int) -> VarRange:
         start = self.next_var
@@ -107,7 +110,14 @@ def test_conditions():
     f = CNF()
     x, y, p = f.new_vars(3)
     f.add_encoding(x ^ y, conditions=[p])
-    assert f.to_dimacs() == "p cnf 3 2\n3 1 2 0\n3 -1 -2 0\n"
+    assert f.to_dimacs() == "p cnf 3 2\n-3 1 2 0\n-3 -1 -2 0\n"
+
+
+def test_add_unsat_with_conditions():
+    f = CNF()
+    x, y, p = f.new_vars(3)
+    f.add_encoding(x + y >= 5, conditions=[p])
+    assert f.to_dimacs() == "p cnf 3 1\n-3 0\n"
 
 
 def test_custom_db():
@@ -122,6 +132,6 @@ def test_custom_db():
 
     f.add_encoding(x ^ y, conditions=[p])
     assert f.clauses == [
-        [4, 2, 3],
-        [4, -2, -3],
+        [-4, 2, 3],
+        [-4, -2, -3],
     ]

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -18,12 +18,21 @@ create_exception!(
 	"Raised when the given constraint is found to be Unsatisfiable during encoding."
 );
 
+// Avoid orphan rule preventing impl PyErr on pindakaas::Unsatisfiable
+struct ErrWrapper(PyErr);
+
 // Use Result i/o PyResult to use `?` to easily return Rust errors as Python
 // exceptions
 type Result<R = (), E = ErrWrapper> = std::result::Result<R, E>;
 
-// Avoid orphan rule preventing impl PyErr on pindakaas::Unsatisfiable
-struct ErrWrapper(PyErr);
+// Allow `pindakaas::Unsatisfiable` to become a wrapped Unsatisfiable exception
+impl From<::pindakaas::Unsatisfiable> for ErrWrapper {
+	fn from(_: ::pindakaas::Unsatisfiable) -> Self {
+		Self(Unsatisfiable::new_err(
+			"The given constraint was found to be Unsatisfiable during encoding",
+		))
+	}
+}
 
 // Allow `pindakaas::Unsatisfiable` to become a wrapped Unsatisfiable exception
 impl<T> From<PoisonError<T>> for ErrWrapper {
@@ -39,15 +48,6 @@ impl From<PyErr> for ErrWrapper {
 	}
 }
 
-// Allow `pindakaas::Unsatisfiable` to become a wrapped Unsatisfiable exception
-impl From<::pindakaas::Unsatisfiable> for ErrWrapper {
-	fn from(_: ::pindakaas::Unsatisfiable) -> Self {
-		Self(Unsatisfiable::new_err(
-			"The given constraint was found to be Unsatisfiable during encoding",
-		))
-	}
-}
-
 // Allow ErrWrapper to become PyErr
 impl From<ErrWrapper> for PyErr {
 	fn from(err: ErrWrapper) -> Self {
@@ -60,17 +60,20 @@ mod pindakaas {
 	use std::{
 		fmt::{self, Display},
 		num::NonZeroI32,
+		sync::Mutex,
 	};
 
+	use itertools::Itertools;
 	use pindakaas::{
 		bool_linear::{
 			AdderEncoder, BoolLinAggregator, BoolLinExp as BaseBoolLinExp, BoolLinVariant,
-			BoolLinear as BaseBoolLinCon, Comparator, SwcEncoder, TotalizerEncoder,
+			BoolLinear as BaseBoolLinCon, Comparator, LinearEncoder, NormalizedBoolLinear,
+			SwcEncoder, TotalizerEncoder,
 		},
-		cardinality::SortingNetworkEncoder,
-		cardinality_one::{BitwiseEncoder, LadderEncoder, PairwiseEncoder},
+		cardinality::{Cardinality, SortingNetworkEncoder},
+		cardinality_one::{BitwiseEncoder, CardinalityOne, LadderEncoder, PairwiseEncoder},
 		propositional_logic::{Formula as BaseFormula, TseitinEncoder},
-		BoolVal, ClauseDatabase, ClauseDatabaseTools, Cnf, Encoder as _, Lit as BaseLit,
+		BoolVal, ClauseDatabase, ClauseDatabaseTools, Cnf, Encoder as EncoderTrait, Lit as BaseLit,
 		VarRange as BaseVarRange, Wcnf,
 	};
 	use pyo3::{exceptions::PyValueError, prelude::*, types::PyIterator};
@@ -170,6 +173,13 @@ mod pindakaas {
 		Lit(Lit),
 	}
 
+	struct LinEncoderWrapper {
+		/// Method chosen by the user.
+		method: Option<Encoder>,
+		/// Error message for an invalid choice.
+		error_message: Mutex<Option<PyErr>>,
+	}
+
 	#[pyclass]
 	#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	/// A Boolean literal, representing a Boolean variable or its negation.
@@ -186,82 +196,6 @@ mod pindakaas {
 	/// associated weights.
 	struct WCNFInner(Wcnf);
 
-	/// Same `encode_constraint`, but evaluates the conditions if not empty.
-	/// This prevents costly virtual method access if this were done inside
-	/// `encode_constraint`
-	fn encode_constraint_with_conditions<Db>(
-		db: &mut Db,
-		con: ConstraintArg,
-		enc: Option<Encoder>,
-		conditions: Vec<Lit>,
-	) -> Result
-	where
-		Db: ClauseDatabase,
-	{
-		if conditions.is_empty() {
-			encode_constraint(db, con, enc)
-		} else {
-			encode_constraint(
-				&mut db.with_conditions(conditions.into_iter().map(|l| l.0).collect()),
-				con,
-				enc,
-			)
-		}
-	}
-
-	/// Internal function to help with the encoding of a constraint given an
-	/// optional encoder.
-	fn encode_constraint<Db>(db: &mut Db, con: ConstraintArg, enc: Option<Encoder>) -> Result
-	where
-		Db: ClauseDatabase,
-	{
-		let invalid_enc = |con_ty, enc| {
-			Err(InvalidEncoder::new_err(format!(
-				"Unable to encode object of type `{con_ty}' using {enc:?}"
-			))
-			.into())
-		};
-
-		match con {
-			ConstraintArg::BoolLin(lin) => {
-				let aggregated = BoolLinAggregator::default().aggregate(db, &lin.0)?;
-				match aggregated {
-					BoolLinVariant::Cardinality(c) => match enc.unwrap_or(Encoder::ADDER) {
-						Encoder::SORTING_NETWORK => SortingNetworkEncoder::default().encode(db, &c),
-						Encoder::ADDER => AdderEncoder::default().encode(db, &c),
-						Encoder::SORTED_WEIGHT_COUNTER => SwcEncoder::default().encode(db, &c),
-						Encoder::TOTALIZER => TotalizerEncoder::default().encode(db, &c),
-						_ => return invalid_enc("Cardinality", enc.unwrap()),
-					},
-					BoolLinVariant::CardinalityOne(c) => match enc.unwrap_or(Encoder::BITWISE) {
-						Encoder::BITWISE => BitwiseEncoder::default().encode(db, &c),
-						Encoder::ADDER => AdderEncoder::default().encode(db, &c),
-						Encoder::LADDER => LadderEncoder::default().encode(db, &c),
-						Encoder::PAIRWISE => PairwiseEncoder::default().encode(db, &c),
-						Encoder::SORTED_WEIGHT_COUNTER => SwcEncoder::default().encode(db, &c),
-						Encoder::SORTING_NETWORK => SortingNetworkEncoder::default().encode(db, &c),
-						Encoder::TOTALIZER => TotalizerEncoder::default().encode(db, &c),
-						_ => return invalid_enc("CardinalityOne", enc.unwrap()),
-					},
-					BoolLinVariant::Linear(lin) => match enc.unwrap_or(Encoder::ADDER) {
-						Encoder::TOTALIZER => TotalizerEncoder::default().encode(db, &lin),
-						Encoder::ADDER => AdderEncoder::default().encode(db, &lin),
-						Encoder::SORTED_WEIGHT_COUNTER => SwcEncoder::default().encode(db, &lin),
-						_ => return invalid_enc("BoolLinear", enc.unwrap()),
-					},
-					BoolLinVariant::Trivial => return Ok(()),
-				}?;
-			}
-			ConstraintArg::Formula(f) => match enc.unwrap_or(Encoder::TSEITIN) {
-				Encoder::TSEITIN => TseitinEncoder.encode(db, &f.0)?,
-				_ => {
-					return invalid_enc("Formula", enc.unwrap());
-				}
-			},
-		};
-		Ok(())
-	}
-
 	#[pyfunction]
 	fn _wrap_encode_constraint(
 		obj: &Bound<'_, PyAny>,
@@ -275,8 +209,8 @@ mod pindakaas {
 				&mut self,
 				clause: &[BaseLit],
 			) -> Result<(), pindakaas::Unsatisfiable> {
-				let clause = clause.iter().map(|&l| Lit(l)).collect_vec();
-				let res = self.0.call_method1("add_clause", (clause,));
+				let clause_vec = clause.iter().map(|&l| Lit(l)).collect_vec();
+				let res = self.0.call_method1("add_clause", (clause_vec,));
 				match res {
 					Err(e) if e.is_instance_of::<Unsatisfiable>(self.0.py()) => {
 						Err(pindakaas::Unsatisfiable)
@@ -284,6 +218,10 @@ mod pindakaas {
 					Err(e) => {
 						panic!("unexpected error in add_clause implementation: {}", e)
 					}
+					// We would have expected the user implementation to raise `Unsatisfiable`, but
+					// is did not. Since encodings depend on this behaviour, we return the error
+					// instead.
+					Ok(_) if clause.is_empty() => Err(pindakaas::Unsatisfiable),
 					Ok(_) => Ok(()),
 				}
 			}
@@ -300,7 +238,54 @@ mod pindakaas {
 			}
 		}
 
-		encode_constraint_with_conditions(&mut PyDbWrapper(obj), con, enc, conditions)
+		encode_constraint(&mut PyDbWrapper(obj), con, enc, conditions)
+	}
+
+	/// Internal function to help with the encoding of a constraint given an
+	/// optional encoder.
+	///
+	/// If conditions are provided, the constraint is encoded to only hold if
+	/// all conditions are true.
+	fn encode_constraint<Db>(
+		db: &mut Db,
+		con: ConstraintArg,
+		enc: Option<Encoder>,
+		conditions: Vec<Lit>,
+	) -> Result
+	where
+		Db: ClauseDatabase + ?Sized,
+	{
+		let invalid_enc = |con_ty, enc| {
+			Err(InvalidEncoder::new_err(format!(
+				"Unable to encode object of type `{con_ty}' using {enc:?}"
+			))
+			.into())
+		};
+		let conditions: Vec<_> = conditions.into_iter().map(|l| l.0).collect();
+
+		match con {
+			ConstraintArg::BoolLin(lin) => {
+				let encoder = LinEncoderWrapper::new(enc);
+				let encoder = LinearEncoder::new(encoder, BoolLinAggregator::default());
+				encoder.encode_implied(db, &conditions, &lin.0)?;
+				let err = encoder
+					.variant_encoder()
+					.error_message
+					.lock()
+					.unwrap()
+					.take();
+				if let Some(err) = err {
+					return Err(err.into());
+				}
+			}
+			ConstraintArg::Formula(f) => match enc.unwrap_or(Encoder::TSEITIN) {
+				Encoder::TSEITIN => TseitinEncoder.encode_implied(db, &conditions, &f.0)?,
+				_ => {
+					return invalid_enc("Formula", enc.unwrap());
+				}
+			},
+		};
+		Ok(())
 	}
 
 	impl BoolLinArg {
@@ -327,10 +312,6 @@ mod pindakaas {
 			let mut res = self.clone();
 			res.__iadd__(other);
 			res
-		}
-
-		fn __radd__(&self, other: BoolLinArg) -> Self {
-			self.__add__(other)
 		}
 
 		fn __eq__(&self, other: i64) -> BoolLinCon {
@@ -383,12 +364,16 @@ mod pindakaas {
 			res
 		}
 
-		fn __rmul__(&self, other: i64) -> Self {
-			self.__mul__(other)
-		}
-
 		fn __neg__(&self) -> Self {
 			Self(-self.0.clone())
+		}
+
+		fn __radd__(&self, other: BoolLinArg) -> Self {
+			self.__add__(other)
+		}
+
+		fn __rmul__(&self, other: i64) -> Self {
+			self.__mul__(other)
 		}
 
 		fn __str__(&self) -> String {
@@ -401,8 +386,6 @@ mod pindakaas {
 			res
 		}
 	}
-
-	use itertools::Itertools;
 
 	#[pymethods]
 	impl CNFInner {
@@ -421,7 +404,7 @@ mod pindakaas {
 			enc: Option<Encoder>,
 			conditions: Vec<Lit>,
 		) -> Result {
-			encode_constraint_with_conditions(&mut self.0, con, enc, conditions)
+			encode_constraint(&mut self.0, con, enc, conditions)
 		}
 
 		fn clauses(&self) -> Vec<Vec<Lit>> {
@@ -458,10 +441,6 @@ mod pindakaas {
 			Self(self.0.clone() & other.as_formula())
 		}
 
-		fn __rand__(&self, other: FormulaArg) -> Self {
-			self.__and__(other)
-		}
-
 		fn __eq__(&self, other: FormulaArg) -> Self {
 			use BaseFormula::*;
 
@@ -478,6 +457,10 @@ mod pindakaas {
 			Self(self.0.clone() & !other.as_formula())
 		}
 
+		fn __invert__(&self) -> Self {
+			Self(!self.0.clone())
+		}
+
 		fn __le__(&self, other: FormulaArg) -> Self {
 			use BaseFormula::*;
 
@@ -488,10 +471,6 @@ mod pindakaas {
 			Self(!self.0.clone() & other.as_formula())
 		}
 
-		fn __invert__(&self) -> Self {
-			Self(!self.0.clone())
-		}
-
 		fn __ne__(&self, other: FormulaArg) -> Self {
 			self.__xor__(other)
 		}
@@ -500,8 +479,16 @@ mod pindakaas {
 			Formula(self.0.clone() | other.as_formula())
 		}
 
+		fn __rand__(&self, other: FormulaArg) -> Self {
+			self.__and__(other)
+		}
+
 		fn __ror__(&self, other: FormulaArg) -> Self {
 			self.__or__(other)
+		}
+
+		fn __rxor__(&self, other: FormulaArg) -> Self {
+			self.__xor__(other)
 		}
 
 		fn __str__(&self) -> String {
@@ -510,10 +497,6 @@ mod pindakaas {
 
 		fn __xor__(&self, other: FormulaArg) -> Self {
 			Formula(self.0.clone() ^ other.as_formula())
-		}
-
-		fn __rxor__(&self, other: FormulaArg) -> Self {
-			self.__xor__(other)
 		}
 	}
 
@@ -527,6 +510,95 @@ mod pindakaas {
 				FormulaArg::Const(b) => Atom(BoolVal::Const(*b)),
 				FormulaArg::Formula(formula) => formula.0.clone(),
 				FormulaArg::Lit(lit) => lit.as_formula(),
+			}
+		}
+	}
+
+	impl LinEncoderWrapper {
+		fn new(method: Option<Encoder>) -> Self {
+			Self {
+				method,
+				error_message: Mutex::new(None),
+			}
+		}
+
+		fn set_err(&self, con_ty: &str, enc: Encoder) {
+			let _ = self
+				.error_message
+				.lock()
+				.unwrap()
+				.replace(InvalidEncoder::new_err(format!(
+					"Unable to encode object of type `{con_ty}' using {enc:?}"
+				)));
+		}
+	}
+
+	impl<Db: ClauseDatabase + ?Sized> EncoderTrait<Db, BoolLinVariant> for LinEncoderWrapper {
+		fn encode(
+			&self,
+			db: &mut Db,
+			con: &BoolLinVariant,
+		) -> Result<(), pindakaas::Unsatisfiable> {
+			match con {
+				BoolLinVariant::Linear(lin) => self.encode(db, lin),
+				BoolLinVariant::Cardinality(card) => self.encode(db, card),
+				BoolLinVariant::CardinalityOne(card1) => self.encode(db, card1),
+				BoolLinVariant::Trivial => Ok(()),
+			}
+		}
+	}
+
+	impl<Db: ClauseDatabase + ?Sized> EncoderTrait<Db, Cardinality> for LinEncoderWrapper {
+		fn encode(&self, db: &mut Db, con: &Cardinality) -> Result<(), pindakaas::Unsatisfiable> {
+			match self.method.unwrap_or(Encoder::ADDER) {
+				Encoder::SORTING_NETWORK => SortingNetworkEncoder::default().encode(db, con),
+				Encoder::ADDER => AdderEncoder::default().encode(db, con),
+				Encoder::SORTED_WEIGHT_COUNTER => SwcEncoder::default().encode(db, con),
+				Encoder::TOTALIZER => TotalizerEncoder::default().encode(db, con),
+				enc => {
+					self.set_err("Cardinality", enc);
+					Ok(())
+				}
+			}
+		}
+	}
+
+	impl<Db: ClauseDatabase + ?Sized> EncoderTrait<Db, CardinalityOne> for LinEncoderWrapper {
+		fn encode(
+			&self,
+			db: &mut Db,
+			con: &CardinalityOne,
+		) -> Result<(), pindakaas::Unsatisfiable> {
+			match self.method.unwrap_or(Encoder::BITWISE) {
+				Encoder::BITWISE => BitwiseEncoder::default().encode(db, con),
+				Encoder::ADDER => AdderEncoder::default().encode(db, con),
+				Encoder::LADDER => LadderEncoder::default().encode(db, con),
+				Encoder::PAIRWISE => PairwiseEncoder::default().encode(db, con),
+				Encoder::SORTED_WEIGHT_COUNTER => SwcEncoder::default().encode(db, con),
+				Encoder::SORTING_NETWORK => SortingNetworkEncoder::default().encode(db, con),
+				Encoder::TOTALIZER => TotalizerEncoder::default().encode(db, con),
+				enc => {
+					self.set_err("CardinalityOne", enc);
+					Ok(())
+				}
+			}
+		}
+	}
+
+	impl<Db: ClauseDatabase + ?Sized> EncoderTrait<Db, NormalizedBoolLinear> for LinEncoderWrapper {
+		fn encode(
+			&self,
+			db: &mut Db,
+			con: &NormalizedBoolLinear,
+		) -> Result<(), pindakaas::Unsatisfiable> {
+			match self.method.unwrap_or(Encoder::ADDER) {
+				Encoder::ADDER => AdderEncoder::default().encode(db, con),
+				Encoder::SORTED_WEIGHT_COUNTER => SwcEncoder::default().encode(db, con),
+				Encoder::TOTALIZER => TotalizerEncoder::default().encode(db, con),
+				enc => {
+					self.set_err("BoolLinear", enc);
+					Ok(())
+				}
 			}
 		}
 	}
@@ -547,15 +619,7 @@ mod pindakaas {
 			self.as_bool_lin_exp().__add__(other)
 		}
 
-		fn __radd__(&self, other: BoolLinArg) -> BoolLinExp {
-			self.__add__(other)
-		}
-
 		fn __and__(&self, other: FormulaArg) -> Formula {
-			Formula(self.as_formula()).__and__(other)
-		}
-
-		fn __rand__(&self, other: FormulaArg) -> Formula {
 			Formula(self.as_formula()).__and__(other)
 		}
 
@@ -571,14 +635,6 @@ mod pindakaas {
 			Formula(self.as_formula()).__gt__(other)
 		}
 
-		fn __le__(&self, other: FormulaArg) -> Formula {
-			Formula(self.as_formula()).__le__(other)
-		}
-
-		fn __lt__(&self, other: FormulaArg) -> Formula {
-			Formula(self.as_formula()).__lt__(other)
-		}
-
 		fn __int__(&self) -> i32 {
 			self.0.into()
 		}
@@ -587,12 +643,16 @@ mod pindakaas {
 			Self(!self.0)
 		}
 
-		fn __mul__(&self, other: i64) -> BoolLinExp {
-			self.as_bool_lin_exp().__mul__(other)
+		fn __le__(&self, other: FormulaArg) -> Formula {
+			Formula(self.as_formula()).__le__(other)
 		}
 
-		fn __rmul__(&self, other: i64) -> BoolLinExp {
-			self.__mul__(other)
+		fn __lt__(&self, other: FormulaArg) -> Formula {
+			Formula(self.as_formula()).__lt__(other)
+		}
+
+		fn __mul__(&self, other: i64) -> BoolLinExp {
+			self.as_bool_lin_exp().__mul__(other)
 		}
 
 		fn __ne__(&self, other: FormulaArg) -> Formula {
@@ -603,8 +663,24 @@ mod pindakaas {
 			Formula(self.as_formula()).__or__(other)
 		}
 
+		fn __radd__(&self, other: BoolLinArg) -> BoolLinExp {
+			self.__add__(other)
+		}
+
+		fn __rand__(&self, other: FormulaArg) -> Formula {
+			Formula(self.as_formula()).__and__(other)
+		}
+
+		fn __rmul__(&self, other: i64) -> BoolLinExp {
+			self.__mul__(other)
+		}
+
 		fn __ror__(&self, other: FormulaArg) -> Formula {
 			self.__or__(other)
+		}
+
+		fn __rxor__(&self, other: FormulaArg) -> Formula {
+			self.__xor__(other)
 		}
 
 		fn __str__(&self) -> String {
@@ -617,10 +693,6 @@ mod pindakaas {
 
 		fn __xor__(&self, other: FormulaArg) -> Formula {
 			Formula(self.as_formula()).__xor__(other)
-		}
-
-		fn __rxor__(&self, other: FormulaArg) -> Formula {
-			self.__xor__(other)
 		}
 
 		#[staticmethod]
@@ -699,7 +771,7 @@ mod pindakaas {
 			enc: Option<Encoder>,
 			conditions: Vec<Lit>,
 		) -> Result {
-			encode_constraint_with_conditions(&mut self.0, con, enc, conditions)
+			encode_constraint(&mut self.0, con, enc, conditions)
 		}
 
 		fn add_weighted_clause(&mut self, clause: Bound<'_, PyIterator>, weight: i64) -> Result {
@@ -768,8 +840,8 @@ mod pindakaas {
 		};
 		use pyo3::{exceptions::PyNotImplementedError, prelude::*, types::PyIterator};
 
-		use super::{encode_constraint_with_conditions, Result};
-		use crate::pindakaas::{ConstraintArg, Encoder, Lit, VarRange};
+		use super::Result;
+		use crate::pindakaas::{encode_constraint, ConstraintArg, Encoder, Lit, VarRange};
 
 		#[pyclass(unsendable)]
 		#[derive(Debug, Default)]
@@ -830,7 +902,7 @@ mod pindakaas {
 				enc: Option<Encoder>,
 				conditions: Vec<Lit>,
 			) -> Result {
-				encode_constraint_with_conditions(&mut self.0, con, enc, conditions)
+				encode_constraint(&mut self.0, con, enc, conditions)
 			}
 
 			#[new]
@@ -894,7 +966,7 @@ mod pindakaas {
 				conditions: Vec<Lit>,
 			) -> Result {
 				let mut guard = self.0.lock().unwrap();
-				encode_constraint_with_conditions(&mut *guard, con, enc, conditions)
+				encode_constraint(&mut *guard, con, enc, conditions)
 			}
 
 			#[new]


### PR DESCRIPTION
Previous version was not resistant against encoders returning
`Unsatisfiable`. However, even if the encoders did correctly post
an empty clause, this approach would continue encoding even though only
the clause that negated the conditions was required.

Supersedes #178.
Supersedes #182.
Resolves #174.
Fixes #175.