### PR TITLE
chore: release

### DIFF
--- a/crates/pindakaas-cadical/CHANGELOG.md
+++ b/crates/pindakaas-cadical/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.3.1...pindakaas-cadical-v0.3.2) - 2026-02-21
+
+### Added
+
+- Windows ARM compatibility
+
 ## [0.3.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.3.0...pindakaas-cadical-v0.3.1) - 2026-02-10
 
 ### Added

--- a/crates/pindakaas-cadical/Cargo.toml
+++ b/crates/pindakaas-cadical/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-cadical"
 description = "build of the Cadical SAT solver for the pindakaas crate"
-version = "0.3.1"
+version = "0.3.2"
 license = "MIT"
 
 include = [

--- a/crates/pindakaas-kissat/CHANGELOG.md
+++ b/crates/pindakaas-kissat/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.1...pindakaas-kissat-v0.2.2) - 2026-02-21
+
+### Added
+
+- Windows ARM compatibility
+
 ## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.0...pindakaas-kissat-v0.2.1) - 2025-11-26
 
 ### Added

--- a/crates/pindakaas-kissat/Cargo.toml
+++ b/crates/pindakaas-kissat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-kissat"
 description = "build of the Kissat SAT solver for the pindakaas crate"
-version = "0.2.1"
+version = "0.2.2"
 license = "MIT"
 
 build = "build.rs"

--- a/crates/pindakaas/CHANGELOG.md
+++ b/crates/pindakaas/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.4.0...pindakaas-v0.4.1) - 2026-02-21
+
+### Other
+
+- updated the following local packages: pindakaas-cadical, pindakaas-kissat
+
 ## [0.4.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.3.0...pindakaas-v0.4.0) - 2026-02-10
 
 ### Added

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas"
 description = "Encoding Integer and Pseudo Boolean constraints into CNF"
-version = "0.4.0"
+version = "0.4.1"
 
 authors.workspace = true
 edition.workspace = true
@@ -27,9 +27,9 @@ libloading = { version = "0.8", optional = true }
 tracing = { workspace = true, optional = true }
 
 # Optional Solver Interfaces
-pindakaas-cadical = { version = "0.3.1", path = "../pindakaas-cadical", optional = true }
+pindakaas-cadical = { version = "0.3.2", path = "../pindakaas-cadical", optional = true }
 pindakaas-intel-sat = { version = "0.2.0", path = "../pindakaas-intel-sat", optional = true }
-pindakaas-kissat = { version = "0.2.1", path = "../pindakaas-kissat", optional = true }
+pindakaas-kissat = { version = "0.2.2", path = "../pindakaas-kissat", optional = true }
 splr = { version = "0.17", optional = true }
 
 [dev-dependencies]

--- a/crates/pyndakaas/CHANGELOG.md
+++ b/crates/pyndakaas/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.4.0...pyndakaas-v0.4.1) - 2026-02-21
+
+### Added
+
+- _set_option for CaDiCaL ([#195](https://github.com/pindakaashq/pindakaas/pull/195))
+- Windows ARM compatibility
+
 ## [0.4.0](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.3.0...pyndakaas-v0.4.0) - 2026-02-10
 
 ### Fixed

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyndakaas"
 description = "Python bindings for the pindakaas crate"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 authors.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.14"
-pindakaas = { version = "0.4.0", path = "../pindakaas", features = ["kissat"] }
+pindakaas = { version = "0.4.1", path = "../pindakaas", features = ["kissat"] }
 pyo3 = "0.26.0"
 
 [lints]


### PR DESCRIPTION



## 🤖 New release

* `pindakaas-cadical`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `pindakaas-kissat`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `pyndakaas`: 0.4.0 -> 0.4.1
* `pindakaas`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `pindakaas-cadical`

<blockquote>

## [0.3.2](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.3.1...pindakaas-cadical-v0.3.2) - 2026-02-21

### Other

- update to latest version of `maturin generate-ci`
</blockquote>

## `pindakaas-kissat`

<blockquote>

## [0.2.2](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.1...pindakaas-kissat-v0.2.2) - 2026-02-21

### Other

- update to latest version of `maturin generate-ci`
</blockquote>

## `pyndakaas`

<blockquote>

## [0.4.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.4.0...pyndakaas-v0.4.1) - 2026-02-21

### Added

- _set_option for CaDiCaL ([#195](https://github.com/pindakaashq/pindakaas/pull/195))

### Other

- update to latest version of `maturin generate-ci`
</blockquote>

## `pindakaas`

<blockquote>

## [0.4.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.4.0...pindakaas-v0.4.1) - 2026-02-21

### Other

- updated the following local packages: pindakaas-cadical, pindakaas-kissat
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).