### PR TITLE
Add _set_option for CaDiCaL

### DIFF
--- a/crates/pyndakaas/python/pindakaas/solver.py
+++ b/crates/pyndakaas/python/pindakaas/solver.py
@@ -114,6 +114,8 @@ class CaDiCaL(Solver):
     def new_var_range(self, n: int):
         return self._inner.new_var_range(n)
 
+    def _set_option(self, option: str, value: int):
+        return self._inner._set_option(option, value)
 
 class Kissat(Solver):
     """The `Kissat <https://github.com/arminbiere/kissat>`_ SAT solver."""

--- a/crates/pyndakaas/python/tests/test_solving.py
+++ b/crates/pyndakaas/python/tests/test_solving.py
@@ -52,3 +52,8 @@ def test_kissat():
 def test_issue_159():
     slv = pindakaas.solver.CaDiCaL()
     assert len(slv.new_vars(1)) == 1
+
+
+def test_set_option():
+    slv = pindakaas.solver.CaDiCaL()
+    slv._set_option("factor", 0)

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -945,7 +945,7 @@ mod pindakaas {
 			}
 
 			fn _set_option(&mut self, name: &str, value: i32) {
-				self.0.set_option(name, value)
+				self.0.set_option(name, value);
 			}
 		}
 

--- a/crates/pyndakaas/src/lib.rs
+++ b/crates/pyndakaas/src/lib.rs
@@ -943,6 +943,10 @@ mod pindakaas {
 					SolveResult::Unknown => (Status::UNKNOWN, HashMap::new()),
 				})
 			}
+
+			fn _set_option(&mut self, name: &str, value: i32) {
+				self.0.set_option(name, value)
+			}
 		}
 
 		#[pymethods]


### PR DESCRIPTION
Just for CaDiCaL, add a mostly unofficial `_set_option` method to circumvent the current regression #189 in cadical by setting `factor` to 0. I didn't look into adding this for the other solvers, as I think the most important part right now is just having a working release (for that, just disabling `factor` until I can reproduce and fix the actual issue would have my preference, but for my situation, this does work as well).
