### PR TITLE
chore: release v0.4.2

### DIFF
--- a/crates/pindakaas/CHANGELOG.md
+++ b/crates/pindakaas/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.4.1...pindakaas-v0.5.0) - 2026-04-17
+
+### Other
+
+- Remove hidden `emitted_vars` methods from `Cadical` and `Kissat`, now that they're no longer required for the Python package.
+
 ## [0.4.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.4.0...pindakaas-v0.4.1) - 2026-02-21
 
 ### Other

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas"
 description = "Encoding Integer and Pseudo Boolean constraints into CNF"
-version = "0.4.1"
+version = "0.5.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/pindakaas/src/bool_linear.rs
+++ b/crates/pindakaas/src/bool_linear.rs
@@ -1343,20 +1343,19 @@ impl BoolLinExp {
 				.map(|(_, i)| i)
 				.sum();
 			match constraint {
-				Some(Constraint::AtMostOne) => {
-					if sum != 0 && terms.iter().filter(|&&&(l, _)| sol.value(l)).count() > 1 {
-						return Err(Unsatisfiable);
-					}
+				Some(Constraint::AtMostOne)
+					if sum != 0 && terms.iter().filter(|&&&(l, _)| sol.value(l)).count() > 1 =>
+				{
+					return Err(Unsatisfiable);
 				}
-				Some(Constraint::ImplicationChain) => {
+				Some(Constraint::ImplicationChain)
 					if terms
 						.iter()
 						.map(|(l, _)| *l)
 						.tuple_windows()
-						.any(|(a, b)| !sol.value(a) & sol.value(b))
-					{
-						return Err(Unsatisfiable);
-					}
+						.any(|(a, b)| !sol.value(a) & sol.value(b)) =>
+				{
+					return Err(Unsatisfiable);
 				}
 				Some(Constraint::Domain { lb, ub }) => {
 					// divide by first coeff to get int assignment
@@ -1368,7 +1367,7 @@ impl BoolLinExp {
 						return Err(Unsatisfiable);
 					}
 				}
-				None => {}
+				_ => {}
 			};
 			total += sum;
 		}
@@ -1440,10 +1439,8 @@ impl<'a> AddAssign<IntEncoding<'a>> for BoolLinExp {
 	fn add_assign(&mut self, rhs: IntEncoding<'a>) {
 		match rhs {
 			IntEncoding::Direct { first, vals } => {
-				let mut k = first;
-				for lit in vals {
+				for (k, lit) in (first..).zip(vals.iter()) {
 					self.terms.push_back((*lit, k));
-					k += 1;
 				}
 				self.constraints.push((Constraint::AtMostOne, vals.len()));
 			}
@@ -1522,10 +1519,8 @@ impl<'a> From<IntEncoding<'a>> for BoolLinExp {
 		match var {
 			IntEncoding::Direct { first, vals } => {
 				let mut terms = VecDeque::with_capacity(vals.len());
-				let mut k = first;
-				for lit in vals {
+				for (k, lit) in (first..).zip(vals.iter()) {
 					terms.push_back((*lit, k));
-					k += 1;
 				}
 				Self {
 					terms,

--- a/crates/pindakaas/src/propositional_logic.rs
+++ b/crates/pindakaas/src/propositional_logic.rs
@@ -333,7 +333,7 @@ impl Formula<Lit> {
 							db.add_clause([name, !lit])?;
 						}
 						// name -> (lit[0] or lit[1] or ...)
-						db.add_clause(once(!name).chain(lits.into_iter()))?;
+						db.add_clause(once(!name).chain(lits))?;
 						name
 					}
 				}
@@ -366,7 +366,7 @@ impl Formula<Lit> {
 					db.add_clause([!name, x, !y])?;
 				}
 				db.add_clause(once(name).chain(lits.iter().map(|&l| !l)))?;
-				db.add_clause(once(name).chain(lits.into_iter()))?;
+				db.add_clause(once(name).chain(lits))?;
 				name
 			}
 			Formula::Xor(sub) => {

--- a/crates/pindakaas/src/solver/kissat.rs
+++ b/crates/pindakaas/src/solver/kissat.rs
@@ -15,7 +15,7 @@ use crate::{
 		},
 		VarFactory,
 	},
-	ClauseDatabaseTools, Cnf, VarRange,
+	ClauseDatabaseTools, Cnf,
 };
 
 #[derive(Debug, Default)]
@@ -23,14 +23,6 @@ use crate::{
 /// [Kissat](https://github.com/arminbiere/kissat) SAT solver.
 pub struct Kissat {
 	store: IpasirStore<Self, VarFactory, 0, 1, 0>,
-}
-
-impl Kissat {
-	// TODO: Unsure whether this is a good idea.
-	#[doc(hidden)]
-	pub fn emitted_vars(&self) -> VarRange {
-		self.store.store.vars.emitted_vars()
-	}
 }
 
 impl AccessIpasirStore for Kissat {

--- a/crates/pyndakaas/CHANGELOG.md
+++ b/crates/pyndakaas/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.4.1...pyndakaas-v0.5.0) - 2026-04-17
+
+### Added
+
+- Use custom `Result` object, implemented in Rust, for solver implementations originating from the Rust Pindakaas library.
+
+### Added
+
+- Fix a `solver.CaDiCaL` error that was caused by `MapResult` creation accessing literals that are meant to only be accessed by CaDiCaL itself.
+
+### Removed
+
+- Remove `solver.MapResult` after it became unused for internal `solver.Solver` implementations.
+
 ## [0.4.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.4.0...pyndakaas-v0.4.1) - 2026-02-21
 
 ### Added

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyndakaas"
 description = "Python bindings for the pindakaas crate"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 
 authors.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.14"
-pindakaas = { version = "0.4.1", path = "../pindakaas", features = ["kissat"] }
+pindakaas = { version = "0.5.0", path = "../pindakaas", features = ["kissat"] }
 pyo3 = "0.26.0"
 
 [lints]


### PR DESCRIPTION



## 🤖 New release

* `pindakaas`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `pyndakaas`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `pindakaas`

<blockquote>

## [0.4.2](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.4.1...pindakaas-v0.4.2) - 2026-04-17

### Fixed

- *(pyndakaas)* use rust `Result` object for rust `Solver`s
</blockquote>

## `pyndakaas`

<blockquote>

## [0.4.2](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.4.1...pyndakaas-v0.4.2) - 2026-04-17

### Fixed

- *(pyndakaas)* use rust `Result` object for rust `Solver`s

### Other

- use attached `Python` reference
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).