### PR TITLE
chore: release v0.5.1

### DIFF
--- a/crates/pindakaas/CHANGELOG.md
+++ b/crates/pindakaas/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.5.0...pindakaas-v0.5.1) - 2026-05-27
+
+### Other
+
+- *(deps)* update rangelist requirement from 0.3.1 to 0.4.0
+- *(deps)* update libloading requirement from 0.8 to 0.9
+
 ## [0.5.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.4.1...pindakaas-v0.5.0) - 2026-04-17
 
 ### Other

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -22,7 +22,7 @@ rustc-hash = "2.0"
 rangelist = "0.3.1"
 
 # Dynamically load solver libraries (through IPASIR interfaces)
-libloading = { version = "0.8", optional = true }
+libloading = { version = "0.9", optional = true }
 # Optional encoding tracing capabilities
 tracing = { workspace = true, optional = true }
 

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas"
 description = "Encoding Integer and Pseudo Boolean constraints into CNF"
-version = "0.5.0"
+version = "0.5.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 [dependencies]
 itertools = "0.14"
 rustc-hash = "2.0"
-rangelist = "0.3.1"
+rangelist = "0.4.0"
 
 # Dynamically load solver libraries (through IPASIR interfaces)
 libloading = { version = "0.9", optional = true }

--- a/crates/pyndakaas/CHANGELOG.md
+++ b/crates/pyndakaas/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.5.0...pyndakaas-v0.5.1) - 2026-05-27
+
+### Other
+
+- updated the following local packages: pindakaas
+
 ## [0.5.0](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.4.1...pyndakaas-v0.5.0) - 2026-04-17
 
 ### Added

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyndakaas"
 description = "Python bindings for the pindakaas crate"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 authors.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.14"
-pindakaas = { version = "0.5.0", path = "../pindakaas", features = ["kissat"] }
+pindakaas = { version = "0.5.1", path = "../pindakaas", features = ["kissat"] }
 pyo3 = "0.26.0"
 
 [lints]


### PR DESCRIPTION



## 🤖 New release

* `pindakaas`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `pyndakaas`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `pindakaas`

<blockquote>

## [0.5.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.5.0...pindakaas-v0.5.1) - 2026-05-27

### Other

- *(deps)* update rangelist requirement from 0.3.1 to 0.4.0
- *(deps)* update libloading requirement from 0.8 to 0.9
</blockquote>

## `pyndakaas`

<blockquote>

## [0.5.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.5.0...pyndakaas-v0.5.1) - 2026-05-27

### Other

- updated the following local packages: pindakaas
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).