### PR TITLE
chore: release

### DIFF
--- a/crates/pindakaas-cadical/CHANGELOG.md
+++ b/crates/pindakaas-cadical/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.3.2...pindakaas-cadical-v0.4.0) - 2026-06-09
+
+### Added
+
+- *(external-propagation)* clone solvers with external propagator
+
 ## [0.3.2](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.3.1...pindakaas-cadical-v0.3.2) - 2026-02-21
 
 ### Added

--- a/crates/pindakaas-cadical/Cargo.toml
+++ b/crates/pindakaas-cadical/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-cadical"
 description = "build of the Cadical SAT solver for the pindakaas crate"
-version = "0.3.2"
+version = "0.4.0"
 license = "MIT"
 
 include = [

--- a/crates/pindakaas/CHANGELOG.md
+++ b/crates/pindakaas/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.5.0...pindakaas-v0.5.1) - 2026-06-09
+
+### Added
+
+- *(external-propagation)* clone solvers with external propagator
+
+### Removed
+
+- *(external-propagation)* remove `Cadical::is_observed`; variable observation is now handled when cloning a solver through the new `Cadical::shallow_clone_with_propagator` method.
+
+### Other
+
+- update dependencies
+- *(deps)* update rangelist requirement from 0.3.1 to 0.4.0
+- *(deps)* update libloading requirement from 0.8 to 0.9
+
 ## [0.5.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.4.1...pindakaas-v0.5.0) - 2026-04-17
 
 ### Other

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas"
 description = "Encoding Integer and Pseudo Boolean constraints into CNF"
-version = "0.5.0"
+version = "0.5.1"
 
 authors.workspace = true
 edition.workspace = true
@@ -27,7 +27,7 @@ libloading = { version = "0.9", optional = true }
 tracing = { workspace = true, optional = true }
 
 # Optional Solver Interfaces
-pindakaas-cadical = { version = "0.3.2", path = "../pindakaas-cadical", optional = true }
+pindakaas-cadical = { version = "0.4.0", path = "../pindakaas-cadical", optional = true }
 pindakaas-intel-sat = { version = "0.2.0", path = "../pindakaas-intel-sat", optional = true }
 pindakaas-kissat = { version = "0.2.2", path = "../pindakaas-kissat", optional = true }
 splr = { version = "0.17", optional = true }

--- a/crates/pyndakaas/CHANGELOG.md
+++ b/crates/pyndakaas/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.5.0...pyndakaas-v0.5.1) - 2026-06-09
+
+### Other
+
+- update dependencies
+
 ## [0.5.0](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.4.1...pyndakaas-v0.5.0) - 2026-04-17
 
 ### Added

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyndakaas"
 description = "Python bindings for the pindakaas crate"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 authors.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.14"
-pindakaas = { version = "0.5.0", path = "../pindakaas", features = ["kissat"] }
+pindakaas = { version = "0.5.1", path = "../pindakaas", features = ["kissat"] }
 pyo3 = "0.28.3"
 
 [lints]


### PR DESCRIPTION



## 🤖 New release

* `pindakaas-cadical`: 0.3.2 -> 0.4.0 (⚠ API breaking changes)
* `pindakaas`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `pyndakaas`: 0.5.0 -> 0.5.1

### ⚠ `pindakaas-cadical` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_missing.ron

Failed in:
  function pindakaas_cadical::ccadical_is_observed, previously in file /tmp/.tmpP8jIsi/pindakaas-cadical/src/lib.rs:180
```

### ⚠ `pindakaas` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/inherent_method_missing.ron

Failed in:
  Cadical::is_observed, previously in file /tmp/.tmpP8jIsi/pindakaas/src/solver/cadical.rs:275
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pindakaas-cadical`

<blockquote>

## [0.4.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.3.2...pindakaas-cadical-v0.4.0) - 2026-06-09

### Added

- *(external-propagation)* clone solvers with external propagator
</blockquote>

## `pindakaas`

<blockquote>

## [0.6.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.5.0...pindakaas-v0.6.0) - 2026-06-09

### Added

- *(external-propagation)* clone solvers with external propagator

### Other

- update dependencies
- *(deps)* update rangelist requirement from 0.3.1 to 0.4.0
- *(deps)* update libloading requirement from 0.8 to 0.9
</blockquote>

## `pyndakaas`

<blockquote>

## [0.5.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.5.0...pyndakaas-v0.5.1) - 2026-06-09

### Other

- update dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).