### PR TITLE
chore: release

### DIFF
--- a/crates/pindakaas-cadical/CHANGELOG.md
+++ b/crates/pindakaas-cadical/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.4.0...pindakaas-cadical-v0.4.1) - 2026-08-03
+
+### Fixed
+
+- C robustness issues
+
 ## [0.4.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.3.2...pindakaas-cadical-v0.4.0) - 2026-06-09
 
 ### Added

--- a/crates/pindakaas-cadical/Cargo.toml
+++ b/crates/pindakaas-cadical/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-cadical"
 description = "build of the Cadical SAT solver for the pindakaas crate"
-version = "0.4.0"
+version = "0.4.1"
 license = "MIT"
 
 include = [

--- a/crates/pindakaas-intel-sat/CHANGELOG.md
+++ b/crates/pindakaas-intel-sat/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-intel-sat-v0.2.0...pindakaas-intel-sat-v0.2.1) - 2026-08-03
+
+### Fixed
+
+- C robustness issues
+
 ## [0.2.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-intel-sat-v0.1.0...pindakaas-intel-sat-v0.2.0) - 2025-09-25
 
 ### Added

--- a/crates/pindakaas-intel-sat/Cargo.toml
+++ b/crates/pindakaas-intel-sat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-intel-sat"
 description = "build of the Intel SAT solver for the pindakaas crate"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 
 build = "build.rs"

--- a/crates/pindakaas-kissat/CHANGELOG.md
+++ b/crates/pindakaas-kissat/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.2...pindakaas-kissat-v0.2.3) - 2026-08-03
+
+### Fixed
+
+- C robustness issues
+
 ## [0.2.2](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.1...pindakaas-kissat-v0.2.2) - 2026-02-21
 
 ### Added

--- a/crates/pindakaas-kissat/Cargo.toml
+++ b/crates/pindakaas-kissat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-kissat"
 description = "build of the Kissat SAT solver for the pindakaas crate"
-version = "0.2.2"
+version = "0.2.3"
 license = "MIT"
 
 build = "build.rs"

--- a/crates/pindakaas/CHANGELOG.md
+++ b/crates/pindakaas/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.5.1...pindakaas-v0.6.0) - 2026-08-03
+
+### Added
+
+- *(external-propagation)* streamline allocation in ExternalPropagation API
+
+### Fixed
+
+- re-enable already working testcases
+- C robustness issues
+
+### Other
+
+- *(external-propagation)* remove ReasonBuilder
+- update itertools from 0.14 to 0.15
+
 ## [0.5.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.5.0...pindakaas-v0.5.1) - 2026-06-09
 
 ### Added

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas"
 description = "Encoding Integer and Pseudo Boolean constraints into CNF"
-version = "0.5.1"
+version = "0.6.0"
 
 authors.workspace = true
 edition.workspace = true
@@ -27,9 +27,9 @@ libloading = { version = "0.9", optional = true }
 tracing = { workspace = true, optional = true }
 
 # Optional Solver Interfaces
-pindakaas-cadical = { version = "0.4.0", path = "../pindakaas-cadical", optional = true }
-pindakaas-intel-sat = { version = "0.2.0", path = "../pindakaas-intel-sat", optional = true }
-pindakaas-kissat = { version = "0.2.2", path = "../pindakaas-kissat", optional = true }
+pindakaas-cadical = { version = "0.4.1", path = "../pindakaas-cadical", optional = true }
+pindakaas-intel-sat = { version = "0.2.1", path = "../pindakaas-intel-sat", optional = true }
+pindakaas-kissat = { version = "0.2.3", path = "../pindakaas-kissat", optional = true }
 splr = { version = "0.17", optional = true }
 
 [dev-dependencies]

--- a/crates/pindakaas/src/bool_linear.rs
+++ b/crates/pindakaas/src/bool_linear.rs
@@ -3296,16 +3296,19 @@ mod tests {
 	}
 	linear_test_suite! {adder_encoder, crate::bool_linear::AdderEncoder::default()}
 
-	// FIXME: BDD does not support LimitComp::Equal
-	// card1_test_suite!(BddEncoder::default());
+	card1_test_suite! {
+		bdd_encoder_card1, crate::bool_linear::AdderEncoder::default()
+	}
 	linear_test_suite! {bdd_encoder, crate::bool_linear::BddEncoder::default()}
 
-	// FIXME: SWC does not support LimitComp::Equal
-	// card1_test_suite!(SwcEncoder::default());
+	card1_test_suite! {
+		swc_encoder_card1, crate::bool_linear::AdderEncoder::default()
+	}
 	linear_test_suite! {swc_encoder, crate::bool_linear::SwcEncoder::default()}
 
-	// FIXME: Totalizer does not support LimitComp::Equal
-	// card1_test_suite!(TotalizerEncoder::default());
+	card1_test_suite! {
+		totalizer_encoder_card1, crate::bool_linear::AdderEncoder::default()
+	}
 	linear_test_suite!(
 		totalizer_encoder,
 		crate::bool_linear::TotalizerEncoder::default()

--- a/crates/pyndakaas/CHANGELOG.md
+++ b/crates/pyndakaas/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.5.1...pyndakaas-v0.5.2) - 2026-08-03
+
+### Fixed
+
+- C robustness issues
+
+### Other
+
+- *(pyndakaas)* build a single abi3 wheel per platform
+- update itertools from 0.14 to 0.15
+- *(deps)* update pyo3 requirement from 0.28.3 to 0.29.0
+
 ## [0.5.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.5.0...pyndakaas-v0.5.1) - 2026-06-09
 
 ### Other

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyndakaas"
 description = "Python bindings for the pindakaas crate"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 authors.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.15"
-pindakaas = { version = "0.5.1", path = "../pindakaas", features = ["kissat"] }
+pindakaas = { version = "0.6.0", path = "../pindakaas", features = ["kissat"] }
 pyo3 = { version = "0.29.0", features = ["abi3-py39"] }
 
 [lints]


### PR DESCRIPTION



## 🤖 New release

* `pindakaas-cadical`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `pindakaas-intel-sat`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `pindakaas-kissat`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `pindakaas`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `pyndakaas`: 0.5.1 -> 0.5.2

### ⚠ `pindakaas` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ClausePersistence:Irredundant in /tmp/.tmpybP6cF/pindakaas/crates/pindakaas/src/solver/propagation.rs:24

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ClausePersistence::Irreduntant, previously in file /tmp/.tmpkjmeKM/pindakaas/src/solver/propagation.rs:17

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_missing.ron

Failed in:
  method add_external_clause of trait Propagator, previously in file /tmp/.tmpkjmeKM/pindakaas/src/solver/propagation.rs:121
  method add_reason_clause of trait Propagator, previously in file /tmp/.tmpkjmeKM/pindakaas/src/solver/propagation.rs:132

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait pindakaas::solver::propagation::PropagatorDefinition, previously in file /tmp/.tmpkjmeKM/pindakaas/src/solver/propagation.rs:188
  trait pindakaas::solver::cadical::ProofTracerDefinition, previously in file /tmp/.tmpkjmeKM/pindakaas/src/solver/cadical.rs:193
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pindakaas-cadical`

<blockquote>

## [0.4.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.4.0...pindakaas-cadical-v0.4.1) - 2026-08-03

### Fixed

- C robustness issues
</blockquote>

## `pindakaas-intel-sat`

<blockquote>

## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-intel-sat-v0.2.0...pindakaas-intel-sat-v0.2.1) - 2026-08-03

### Fixed

- C robustness issues
</blockquote>

## `pindakaas-kissat`

<blockquote>

## [0.2.3](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.2...pindakaas-kissat-v0.2.3) - 2026-08-03

### Fixed

- C robustness issues
</blockquote>

## `pindakaas`

<blockquote>

## [0.6.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.5.1...pindakaas-v0.6.0) - 2026-08-03

### Added

- *(external-propagation)* streamline allocation in ExternalPropagation API

### Fixed

- re-enable already working testcases
- C robustness issues

### Other

- *(external-propagation)* remove ReasonBuilder
- update itertools from 0.14 to 0.15
</blockquote>

## `pyndakaas`

<blockquote>

## [0.5.2](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.5.1...pyndakaas-v0.5.2) - 2026-08-03

### Fixed

- C robustness issues

### Other

- *(pyndakaas)* build a single abi3 wheel per platform
- update itertools from 0.14 to 0.15
- *(deps)* update pyo3 requirement from 0.28.3 to 0.29.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).