### PR TITLE
feat(external-propagation): streamline allocation in ExternalPropagation API

### DIFF
--- a/crates/pindakaas/src/lib.rs
+++ b/crates/pindakaas/src/lib.rs
@@ -587,6 +587,7 @@ pub enum IntEncoding<'a> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 /// Literal is type that can be use to represent Boolean decision variables and
 /// their negations
 pub struct Lit(NonZeroI32);

--- a/crates/pindakaas/src/solver/cadical.rs
+++ b/crates/pindakaas/src/solver/cadical.rs
@@ -26,7 +26,7 @@ use pindakaas_cadical::{
 #[cfg(feature = "external-propagation")]
 use crate::solver::{
 	ipasir::user_propagation::{IpasirPropagatorStorage, IpasirUserPropagationMethods},
-	propagation::PropagatorDefinition,
+	propagation::PropagatorConfig,
 };
 use crate::{
 	helpers::opt_field::OptField,
@@ -174,6 +174,17 @@ pub trait ProofTracer {
 	}
 }
 
+/// Trait that gives extra information about the [`ProofTracer`] implementation.
+/// This information is used to optimize the interaction between the
+/// [`ProofTracer`] and the solver.
+pub trait ProofTracerConfig: ProofTracer {
+	/// Whether the [`ProofTracer`] uses the antecedents of derived clauses.
+	const ANTECEDENTS: bool;
+	/// Whether the [`ProofTracer`] needs the solver to finalize non-deleted
+	/// clauses in proof.
+	const FINALIZE_CLAUSES: bool = false;
+}
+
 fn cadical_next_var(slv: *mut c_void, _: *mut c_void) -> i32 {
 	// SAFETY: Pointer is guaranteed to point to a valid and initialized
 	// CCadical instance.
@@ -187,25 +198,11 @@ fn cadical_next_var_range(slv: *mut c_void, _: *mut c_void, len: usize) -> [i32;
 	[end + 1 - len as i32, end]
 }
 
-/// Trait that gives extra information about the [`ProofTracer`] implementation.
-/// This information is used to optimize the interaction between the
-/// [`ProofTracer`] and the solver.
-pub trait ProofTracerDefinition: ProofTracer {
-	/// Whether the [`ProofTracer`] uses the antecedents of derived clauses.
-	const ANTECEDENTS: bool;
-	/// Whether the [`ProofTracer`] needs the solver to finalize non-deleted
-	/// clauses in proof.
-	const FINALIZE_CLAUSES: bool = false;
-}
-
 impl Cadical {
 	// TODO: Hidden for now as it requires the user to set the proof tracer during
 	// CONFIGURATION. This should probably be a separate state/builder.
 	#[doc(hidden)]
-	pub fn connect_proof_tracer<P: ProofTracerDefinition + 'static>(
-		&mut self,
-		tracer: Rc<RefCell<P>>,
-	) {
+	pub fn connect_proof_tracer<P: ProofTracerConfig + 'static>(&mut self, tracer: Rc<RefCell<P>>) {
 		let ptr = Rc::as_ptr(&tracer);
 		let ctracer = CTracer {
 			data: ptr as *mut c_void,
@@ -331,7 +328,7 @@ impl Cadical {
 	/// must supply an appropriate clone of the propagator, since the
 	/// propagator's own state cannot be cloned automatically.
 	#[cfg(feature = "external-propagation")]
-	pub fn shallow_clone_with_propagator<P: PropagatorDefinition + 'static>(
+	pub fn shallow_clone_with_propagator<P: PropagatorConfig + 'static>(
 		&self,
 		propagator: Rc<RefCell<P>>,
 	) -> Self {
@@ -413,13 +410,6 @@ impl IpasirAssumptionMethods for Cadical {
 	const IPASIR_FAILED: unsafe extern "C" fn(*mut c_void, i32) -> c_int = ccadical_failed;
 }
 
-impl IpasirLiteralMethods for Cadical {
-	const IPASIR_NEW_RANGE: fn(slv: *mut c_void, vars: *mut c_void, len: usize) -> [i32; 2] =
-		cadical_next_var_range;
-
-	const IPASIR_NEW_VAR: fn(slv: *mut c_void, vars: *mut c_void) -> i32 = cadical_next_var;
-}
-
 impl IpasirLearnCallbackMethod for Cadical {
 	const IPASIR_SET_LEARN_CALLBACK: unsafe extern "C" fn(
 		*mut c_void,
@@ -427,6 +417,13 @@ impl IpasirLearnCallbackMethod for Cadical {
 		c_int,
 		Option<unsafe extern "C" fn(*mut c_void, *const i32)>,
 	) = ccadical_set_learn;
+}
+
+impl IpasirLiteralMethods for Cadical {
+	const IPASIR_NEW_RANGE: fn(slv: *mut c_void, vars: *mut c_void, len: usize) -> [i32; 2] =
+		cadical_next_var_range;
+
+	const IPASIR_NEW_VAR: fn(slv: *mut c_void, vars: *mut c_void) -> i32 = cadical_next_var;
 }
 
 impl IpasirSolverMethods for Cadical {
@@ -809,6 +806,63 @@ mod tests {
 		assert!(matches!(slv.solve(), SolveResult::Satisfied(_)));
 	}
 
+	#[cfg(feature = "external-propagation")]
+	#[test]
+	fn shallow_clone_with_propagator_observes() {
+		use std::{cell::RefCell, collections::HashSet, rc::Rc};
+
+		use crate::{
+			solver::propagation::{ExternalPropagation, Propagator, PropagatorConfig},
+			ClauseDatabase, Lit,
+		};
+
+		// A propagator that records every assignment notification it receives. A
+		// non-lazy propagator is only notified about *observed* variables, so a
+		// non-empty record on the clone proves the observed set was transferred.
+		#[derive(Default)]
+		struct Recorder {
+			notified: Vec<Lit>,
+		}
+		impl Propagator for Recorder {
+			fn notify_assignment(&mut self, lits: &[Lit]) {
+				self.notified.extend_from_slice(lits);
+			}
+		}
+		impl PropagatorConfig for Recorder {}
+
+		let mut slv = Cadical::default();
+		let vars = slv.new_var_range(3);
+		// Force every variable so that solving assigns all of them.
+		for v in vars {
+			slv.add_clause([v]).unwrap();
+		}
+
+		let p = Rc::new(RefCell::new(Recorder::default()));
+		slv.connect_propagator(Rc::clone(&p));
+		for v in vars {
+			slv.add_observed_var(v);
+		}
+
+		// Clone with a fresh recorder; the clone must re-observe `vars`.
+		let cp_p = Rc::new(RefCell::new(Recorder::default()));
+		let mut cp = slv.shallow_clone_with_propagator(Rc::clone(&cp_p));
+
+		assert!(matches!(cp.solve(), SolveResult::Satisfied(_)));
+
+		// The clone's propagator must have been notified about every observed
+		// variable, proving the observations were copied onto the clone.
+		let notified: HashSet<Lit> = cp_p.borrow().notified.iter().copied().collect();
+		for v in vars {
+			assert!(
+				notified.contains(&v.into()),
+				"clone propagator was not notified about observed variable {v:?}"
+			);
+		}
+
+		drop(cp);
+		assert_eq!(Rc::strong_count(&cp_p), 1);
+	}
+
 	#[test]
 	fn solve() {
 		let mut slv = Cadical::default();
@@ -906,8 +960,8 @@ mod tests {
 			helpers::tests::assert_solutions,
 			solver::{
 				propagation::{
-					ClausePersistence, ExternalPropagation, Propagator, PropagatorDefinition,
-					SolvingActions,
+					ClauseBuilder, ClausePersistence, ExternalPropagation, Propagator,
+					PropagatorConfig, Solution, SolvingActions,
 				},
 				VarRange,
 			},
@@ -926,7 +980,7 @@ mod tests {
 			fn check_solution(
 				&mut self,
 				_slv: &mut dyn SolvingActions,
-				model: &dyn crate::Valuation,
+				model: Solution<'_>,
 			) -> bool {
 				let mut vars = self.vars.clone();
 				while let Some(v) = vars.next() {
@@ -941,14 +995,17 @@ mod tests {
 				}
 				self.tmp.is_empty()
 			}
-			fn add_external_clause(
+			fn provide_clause(
 				&mut self,
 				_slv: &mut dyn SolvingActions,
-			) -> Option<(Vec<Lit>, ClausePersistence)> {
-				self.tmp.pop().map(|c| (c, ClausePersistence::Forgettable))
+				mut clause: ClauseBuilder<'_>,
+			) -> Option<ClausePersistence> {
+				let c = self.tmp.pop()?;
+				clause.extend(c);
+				Some(ClausePersistence::Forgettable)
 			}
 		}
-		impl PropagatorDefinition for Dist2 {
+		impl PropagatorConfig for Dist2 {
 			const CHECK_ONLY: bool = true;
 		}
 
@@ -1012,8 +1069,8 @@ mod tests {
 		use crate::{
 			solver::{
 				propagation::{
-					ClausePersistence, ExternalPropagation, Propagator, PropagatorDefinition,
-					SolvingActions,
+					ClauseBuilder, ClausePersistence, ExternalPropagation, Propagator,
+					PropagatorConfig, Solution, SolvingActions,
 				},
 				VarRange,
 			},
@@ -1028,7 +1085,7 @@ mod tests {
 			fn check_solution(
 				&mut self,
 				_slv: &mut dyn SolvingActions,
-				model: &dyn crate::Valuation,
+				model: Solution<'_>,
 			) -> bool {
 				let mut vars = self.vars.clone();
 				while let Some(v) = vars.next() {
@@ -1043,14 +1100,17 @@ mod tests {
 				}
 				self.tmp.is_empty()
 			}
-			fn add_external_clause(
+			fn provide_clause(
 				&mut self,
 				_slv: &mut dyn SolvingActions,
-			) -> Option<(Vec<Lit>, ClausePersistence)> {
-				self.tmp.pop().map(|c| (c, ClausePersistence::Forgettable))
+				mut clause: ClauseBuilder<'_>,
+			) -> Option<ClausePersistence> {
+				let c = self.tmp.pop()?;
+				clause.extend(c);
+				Some(ClausePersistence::Forgettable)
 			}
 		}
-		impl PropagatorDefinition for Dist2 {
+		impl PropagatorConfig for Dist2 {
 			const CHECK_ONLY: bool = true;
 		}
 
@@ -1113,63 +1173,6 @@ mod tests {
 		assert!(cp_p.borrow().tmp.is_empty());
 
 		// Test correct release of the cloned propagator on drop.
-		drop(cp);
-		assert_eq!(Rc::strong_count(&cp_p), 1);
-	}
-
-	#[cfg(feature = "external-propagation")]
-	#[test]
-	fn shallow_clone_with_propagator_observes() {
-		use std::{cell::RefCell, collections::HashSet, rc::Rc};
-
-		use crate::{
-			solver::propagation::{ExternalPropagation, Propagator, PropagatorDefinition},
-			ClauseDatabase, Lit,
-		};
-
-		// A propagator that records every assignment notification it receives. A
-		// non-lazy propagator is only notified about *observed* variables, so a
-		// non-empty record on the clone proves the observed set was transferred.
-		#[derive(Default)]
-		struct Recorder {
-			notified: Vec<Lit>,
-		}
-		impl Propagator for Recorder {
-			fn notify_assignment(&mut self, lits: &[Lit]) {
-				self.notified.extend_from_slice(lits);
-			}
-		}
-		impl PropagatorDefinition for Recorder {}
-
-		let mut slv = Cadical::default();
-		let vars = slv.new_var_range(3);
-		// Force every variable so that solving assigns all of them.
-		for v in vars {
-			slv.add_clause([v]).unwrap();
-		}
-
-		let p = Rc::new(RefCell::new(Recorder::default()));
-		slv.connect_propagator(Rc::clone(&p));
-		for v in vars {
-			slv.add_observed_var(v);
-		}
-
-		// Clone with a fresh recorder; the clone must re-observe `vars`.
-		let cp_p = Rc::new(RefCell::new(Recorder::default()));
-		let mut cp = slv.shallow_clone_with_propagator(Rc::clone(&cp_p));
-
-		assert!(matches!(cp.solve(), SolveResult::Satisfied(_)));
-
-		// The clone's propagator must have been notified about every observed
-		// variable, proving the observations were copied onto the clone.
-		let notified: HashSet<Lit> = cp_p.borrow().notified.iter().copied().collect();
-		for v in vars {
-			assert!(
-				notified.contains(&v.into()),
-				"clone propagator was not notified about observed variable {v:?}"
-			);
-		}
-
 		drop(cp);
 		assert_eq!(Rc::strong_count(&cp_p), 1);
 	}

--- a/crates/pindakaas/src/solver/ipasir/user_propagation.rs
+++ b/crates/pindakaas/src/solver/ipasir/user_propagation.rs
@@ -1,6 +1,5 @@
 use std::{
 	cell::{RefCell, RefMut},
-	collections::VecDeque,
 	ffi::c_void,
 	fmt,
 	marker::PhantomData,
@@ -10,7 +9,6 @@ use std::{
 };
 
 use pindakaas_cadical::{CExternalPropagator, CFixedAssignmentListener};
-use rustc_hash::FxHashMap;
 
 use crate::{
 	solver::{
@@ -19,9 +17,9 @@ use crate::{
 			IpasirStore, IpasirStoreInner,
 		},
 		propagation::{
-			ClausePersistence, ExternalPropagation, PersistentAssignmentListener,
-			PersistentAssignmentNotifier, Propagator, PropagatorDefinition, SearchDecision,
-			SolvingActions,
+			ClauseBuilder, ClausePersistence, ExternalPropagation, PersistentAssignmentListener,
+			PersistentAssignmentNotifier, Propagator, PropagatorConfig, ReasonBuilder,
+			SearchDecision, Solution, SolvingActions,
 		},
 	},
 	Lit, Var,
@@ -51,12 +49,16 @@ pub(crate) struct IpasirPropagator {
 	/// correctly released (and dropped) when the [`IpasirSolver`] is dropped.
 	/// It is given by the solver using a pointer.
 	persistent_assignment_listener: Option<Rc<RefCell<dyn PersistentAssignmentListener>>>,
-	/// Reason clause queue
-	reason_queue: VecDeque<Lit>,
-	/// The current literal that is being explained
+	/// Reusable buffer holding the clause currently being yielded to the
+	/// solver: a reason clause when `explaining` is set, or an external clause
+	/// when `clause_active` is set. At most one of the two is yielded at a
+	/// time, so a single buffer suffices.
+	clause: Vec<Lit>,
+	/// The literal whose reason clause is currently in `clause`, or `None` when
+	/// a reason clause is not being yielded.
 	explaining: Option<Lit>,
-	/// Queue of literals for the external clause to be yielded.
-	clause_queue: Option<VecDeque<Lit>>,
+	/// Whether an external clause is currently being yielded from `clause`.
+	clause_active: bool,
 }
 
 /// Helper trait that allows abstraction over different [`IpasirStore`] generics
@@ -87,7 +89,7 @@ pub(crate) trait IpasirPropagatorStorage {
 	/// Stores a new propagator in the storage, returning the
 	/// [`CExternalPropagator`] that can be passed to the solver's C methods to
 	/// register the propagator.
-	fn set_propagator<P: PropagatorDefinition + 'static>(
+	fn set_propagator<P: PropagatorConfig + 'static>(
 		&mut self,
 		propagator: Rc<RefCell<P>>,
 	) -> CExternalPropagator;
@@ -140,10 +142,7 @@ where
 		}
 	}
 
-	fn connect_propagator<P: PropagatorDefinition + 'static>(
-		&mut self,
-		propagator: Rc<RefCell<P>>,
-	) {
+	fn connect_propagator<P: PropagatorConfig + 'static>(&mut self, propagator: Rc<RefCell<P>>) {
 		// Disconnect previous propagator (if any)
 		self.disconnect_propagator();
 
@@ -251,16 +250,41 @@ where
 }
 
 impl IpasirPropagator {
-	/// Borrow the propagator in the `external_propagator` field, as a specific
-	/// type `P`.
+	/// Borrow the connected propagator, stored in the given `cell`, as a
+	/// specific type `P`.
 	///
 	/// This method is unsafe because it requires that the propagator is of type
 	/// `P` and the cell is not borrowed. If the propagator is not of type `P`
 	/// or if the cell is already borrowed, this method will panic.
-	unsafe fn borrow_propagator_mut<P>(&self) -> RefMut<'_, P> {
-		let cell: *const _ = Rc::as_ptr(self.external_propagator.as_ref().unwrap());
-		let ptr = cell as *const RefCell<P>;
+	unsafe fn borrow_cell<P>(cell: &Rc<RefCell<dyn Propagator>>) -> RefMut<'_, P> {
+		let ptr = Rc::as_ptr(cell) as *const RefCell<P>;
 		(&*ptr).borrow_mut()
+	}
+
+	/// Borrow the propagator in the `external_propagator` field, as a specific
+	/// type `P`.
+	///
+	/// See [`Self::borrow_cell`] for the safety requirements.
+	unsafe fn borrow_propagator_mut<P>(&self) -> RefMut<'_, P> {
+		Self::borrow_cell(self.external_propagator.as_ref().unwrap())
+	}
+
+	/// Call `f` with the propagator (as a specific type `P`) and a mutable
+	/// reference to the reusable `clause` buffer.
+	///
+	/// Building a reason or external clause needs both at once: the propagator
+	/// writes its literals into the buffer through the builder. Scoping the
+	/// borrows to `f` keeps the pointer handling of [`Self::borrow_cell`] in a
+	/// single place (rather than inlined at each call site) and releases the
+	/// propagator borrow before the caller touches `self` again.
+	///
+	/// See [`Self::borrow_cell`] for the safety requirements.
+	unsafe fn with_propagator_and_clause<P, R>(
+		&mut self,
+		f: impl FnOnce(&mut P, &mut Vec<Lit>) -> R,
+	) -> R {
+		let mut propagator = Self::borrow_cell::<P>(self.external_propagator.as_ref().unwrap());
+		f(&mut propagator, &mut self.clause)
 	}
 }
 
@@ -274,9 +298,9 @@ impl fmt::Debug for IpasirPropagator {
 					x as *const c_void
 				}),
 			)
-			.field("reason_queue", &self.reason_queue)
+			.field("clause", &self.clause)
 			.field("explaining", &self.explaining)
-			.field("clause_queue", &self.clause_queue)
+			.field("clause_active", &self.clause_active)
 			.finish()
 	}
 }
@@ -328,16 +352,17 @@ impl<
 {
 	unsafe extern "C" fn add_external_clause_lit(store: *mut c_void) -> i32 {
 		let store = &mut *(store as *mut IpasirStoreInner<VarStore, LRN, TRM, 1>);
-		let prop = &mut store.propagator.some_mut();
-		let Some(queue) = &mut prop.clause_queue else {
+		let prop = store.propagator.some_mut();
+		if !prop.clause_active {
 			debug_assert!(false, "has_external_clause did not return true");
 			return 0;
-		};
-		if let Some(l) = queue.pop_front() {
-			l.0.get()
-		} else {
-			prop.clause_queue = None;
-			0 // End of clause
+		}
+		match prop.clause.pop() {
+			Some(l) => l.0.get(),
+			None => {
+				prop.clause_active = false;
+				0 // End of clause
+			}
 		}
 	}
 
@@ -346,24 +371,31 @@ impl<
 		propagated_lit: i32,
 	) -> i32 {
 		let store = &mut *(store as *mut IpasirStoreInner<VarStore, LRN, TRM, 1>);
-		let prop = &mut store.propagator.some_mut();
+		let prop = store.propagator.some_mut();
 		let lit = Lit(NonZeroI32::new(propagated_lit).unwrap());
-		debug_assert!(prop.explaining.is_none() || prop.explaining == Some(lit));
-		// // TODO: Can this be prop.explaining.is_none()?
+		// A reason and an external clause share `clause` and are never yielded
+		// simultaneously.
+		debug_assert!(!prop.clause_active);
+
+		// When this is a fresh request (we are not already yielding `lit`'s reason),
+		// construct the clause: seed it with the explained literal, then let the
+		// propagator append the (negated) premises.
 		if prop.explaining != Some(lit) {
-			let new_reason = {
-				let mut user_prop: RefMut<P> = prop.borrow_propagator_mut();
-				user_prop.add_reason_clause(lit)
-			};
-			prop.reason_queue = new_reason.into();
+			prop.clause.clear();
+			prop.clause.push(lit);
+			prop.with_propagator_and_clause::<P, _>(|propagator, clause| {
+				propagator.explain_propagation(lit, ReasonBuilder::new(clause));
+			});
 			prop.explaining = Some(lit);
 		}
-		if let Some(l) = prop.reason_queue.pop_front() {
-			l.0.into()
-		} else {
-			// End of explanation
-			prop.explaining = None;
-			0
+
+		// Yield the members of the constructed clause, then the end-of-clause `0`.
+		match prop.clause.pop() {
+			Some(lit) => lit.0.get(),
+			None => {
+				prop.explaining = None;
+				0
+			}
 		}
 	}
 
@@ -373,16 +405,16 @@ impl<
 		len: usize,
 	) -> bool {
 		let store = &mut *(store as *mut IpasirStoreInner<VarStore, LRN, TRM, 1>);
-		let sol = if len > 0 {
-			slice::from_raw_parts(model, len)
+		let model: &[Lit] = if len > 0 {
+			// SAFETY: `model` points to `len` model literals provided by the solver,
+			// each a non-zero `i32`. `Lit` is `#[repr(transparent)]` over
+			// `NonZeroI32` (and thus over `i32`), so reinterpreting the non-zero
+			// literals as `Lit` is sound.
+			unsafe { slice::from_raw_parts(model as *const Lit, len) }
 		} else {
 			&[]
 		};
-		let sol: FxHashMap<Var, bool> = sol
-			.iter()
-			.map(|&i| (Var(NonZeroI32::new(i.abs()).unwrap()), i >= 0))
-			.collect();
-		let value = |l: Lit| sol.get(&l.var()).copied().unwrap_or(false);
+		let solution = Solution::new(model);
 		let vars: *mut VarStore = &mut store.vars;
 		let mut slv = IpasirSolvingActions::<Impl> {
 			ptr: store.ptr,
@@ -394,7 +426,7 @@ impl<
 			.as_ref()
 			.unwrap()
 			.borrow_propagator_mut::<P>()
-			.check_solution(&mut slv, &value)
+			.check_solution(&mut slv, solution)
 	}
 	unsafe extern "C" fn decide<P: Propagator>(store: *mut c_void) -> i32 {
 		let store = &mut *(store as *mut IpasirStoreInner<VarStore, LRN, TRM, 1>);
@@ -435,14 +467,23 @@ impl<
 			_methods: PhantomData,
 		};
 		let prop = store.propagator.some_mut();
-		let ext_clause = prop
-			.borrow_propagator_mut::<P>()
-			.add_external_clause(&mut slv);
-		if let Some((clause, p)) = ext_clause {
+		// A reason and an external clause share `clause` and are never yielded
+		// simultaneously.
+		debug_assert!(prop.explaining.is_none());
+		debug_assert!(prop.clause.is_empty());
+		debug_assert!(!prop.clause_active);
+		prop.clause.clear();
+		let persistence = prop.with_propagator_and_clause::<P, _>(|propagator, clause| {
+			propagator.provide_clause(&mut slv, ClauseBuilder::new(clause))
+		});
+		if let Some(p) = persistence {
 			*is_forgettable = p == ClausePersistence::Forgettable;
-			prop.clause_queue = Some(clause.into());
+			prop.clause_active = true;
+			true
+		} else {
+			prop.clause_active = false;
+			false
 		}
-		prop.clause_queue.is_some()
 	}
 
 	unsafe extern "C" fn notify_assignment<P: Propagator>(
@@ -468,9 +509,9 @@ impl<
 	) {
 		let store = &mut *(store as *mut IpasirStoreInner<VarStore, LRN, TRM, 1>);
 		let prop = store.propagator.some_mut();
+		prop.clause.clear();
 		prop.explaining = None;
-		prop.reason_queue.clear();
-		prop.clause_queue = None;
+		prop.clause_active = false;
 		prop.borrow_propagator_mut::<P>()
 			.notify_backtrack(level, restart);
 	}
@@ -546,9 +587,9 @@ where
 	fn reset_propagator(&mut self) {
 		let prop_store = self.store.propagator.some_mut();
 		prop_store.external_propagator = None;
-		prop_store.reason_queue.clear();
+		prop_store.clause.clear();
 		prop_store.explaining = None;
-		prop_store.clause_queue = None;
+		prop_store.clause_active = false;
 	}
 
 	fn set_persistent_listener<L: PersistentAssignmentListener + 'static>(
@@ -578,7 +619,7 @@ where
 		}
 	}
 
-	fn set_propagator<P: PropagatorDefinition + 'static>(
+	fn set_propagator<P: PropagatorConfig + 'static>(
 		&mut self,
 		propagator: Rc<RefCell<P>>,
 	) -> CExternalPropagator {

--- a/crates/pindakaas/src/solver/propagation.rs
+++ b/crates/pindakaas/src/solver/propagation.rs
@@ -3,7 +3,14 @@
 
 use std::{cell::RefCell, rc::Rc};
 
-use crate::{solver::Solver, Lit, Valuation, Var};
+use crate::{solver::Solver, Lit, Var};
+
+/// A builder for a clause (a disjunction of literals) being communicated to the
+/// solver (see [`Propagator::provide_clause`]).
+#[derive(Debug)]
+pub struct ClauseBuilder<'a> {
+	clause: &'a mut Vec<Lit>,
+}
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 /// Whether a clause could possibly be removed from the clause database.
@@ -12,9 +19,9 @@ pub enum ClausePersistence {
 	/// the solver's correctness (in combination with the propagator), and it
 	/// can be re-derived if needed.
 	Forgettable,
-	/// The clause is to be considered irreduntant. It contains information that
+	/// The clause is to be considered irredundant. It contains information that
 	/// can not (easily) be re-derived.
-	Irreduntant,
+	Irredundant,
 }
 
 /// Trait implemented by [`Solver`]s that allow connecting an external
@@ -39,7 +46,7 @@ pub trait ExternalPropagation: Solver {
 	/// Only one [`Propagator`] can be connected, any previously connected
 	/// [`Propagator`]s will be disconnected (see
 	/// [`Self::disconnect_propagator`]).
-	fn connect_propagator<P: PropagatorDefinition + 'static>(&mut self, propagator: Rc<RefCell<P>>);
+	fn connect_propagator<P: PropagatorConfig + 'static>(&mut self, propagator: Rc<RefCell<P>>);
 
 	/// Disconnect any previously connected a [`Propagator`] (using
 	/// [`Self::connect_propagator`])
@@ -117,28 +124,11 @@ pub trait PersistentAssignmentNotifier: Solver {
 /// Trait implemented to provide external propagation for [`Solver`]s
 /// implementing the [`ExternalPropagation`] trait.
 pub trait Propagator {
-	/// Method to ask whether there is an external clause to add to the solver.
-	fn add_external_clause(
-		&mut self,
-		slv: &mut dyn SolvingActions,
-	) -> Option<(Vec<Lit>, ClausePersistence)> {
-		let _ = slv;
-		None
-	}
-
-	/// Ask the external propagator for the reason clause of a previous external
-	/// propagation step (done by [`Propagator::propagate`]). The clause must
-	/// contain the propagated literal.
-	fn add_reason_clause(&mut self, propagated_lit: Lit) -> Vec<Lit> {
-		let _ = propagated_lit;
-		Vec::new()
-	}
-
-	/// Method called to check the found complete solution (after solution
+	/// Method called to check the found complete `solution` (after solution
 	/// reconstruction). If it returns false, the propagator must provide an
 	/// external clause during the next callback.
-	fn check_solution(&mut self, slv: &mut dyn SolvingActions, value: &dyn Valuation) -> bool {
-		let _ = value;
+	fn check_solution(&mut self, slv: &mut dyn SolvingActions, solution: Solution<'_>) -> bool {
+		let _ = solution;
 		let _ = slv;
 		true
 	}
@@ -151,6 +141,18 @@ pub trait Propagator {
 	fn decide(&mut self, slv: &mut dyn SolvingActions) -> SearchDecision {
 		let _ = slv;
 		SearchDecision::Free
+	}
+
+	/// Ask the propagator to explain a literal it previously propagated (using
+	/// [`Propagator::propagate`]).
+	///
+	/// The propagator pushes the premises — the literals that currently hold
+	/// and together caused `propagated_lit` to be propagated — into `reason`.
+	/// The solver constructs the reason clause from these premises, so the
+	/// propagator must not negate them or add `propagated_lit` itself.
+	fn explain_propagation(&mut self, propagated_lit: Lit, reason: ReasonBuilder<'_>) {
+		let _ = propagated_lit;
+		let _ = reason;
 	}
 
 	/// Method called to notify the propagator about assignments of literals
@@ -172,12 +174,30 @@ pub trait Propagator {
 	/// Method called to notify the propagator about a new decision level.
 	fn notify_new_decision_level(&mut self) {}
 
-	/// Method to ask the propagator if there is an propagation to make under
-	/// the current assignment. It returns queue of literals to be propagated
-	/// in order, if an empty queue is returned it indicates that there is no
-	/// propagation under the current assignment.
+	/// Ask the propagator for the next literal to propagate under the current
+	/// assignment.
+	///
+	/// This is called repeatedly: each call returns one literal to propagate,
+	/// and `None` indicates that there is nothing (more) to propagate under
+	/// the current assignment.
 	fn propagate(&mut self, slv: &mut dyn SolvingActions) -> Option<Lit> {
 		let _ = slv;
+		None
+	}
+
+	/// Ask the propagator to provide a clause to add to the solver.
+	///
+	/// If there is a clause to provide, the propagator pushes its literals into
+	/// `clause` and returns its [`ClausePersistence`]. Returning `None` (and
+	/// leaving `clause` untouched) indicates that there is no clause to
+	/// provide.
+	fn provide_clause(
+		&mut self,
+		slv: &mut dyn SolvingActions,
+		clause: ClauseBuilder<'_>,
+	) -> Option<ClausePersistence> {
+		let _ = slv;
+		let _ = clause;
 		None
 	}
 }
@@ -185,7 +205,7 @@ pub trait Propagator {
 /// Trait that gives extra information about the [`Propagator`] implementation.
 /// This information is used to optimize the interaction between the
 /// [`Propagator`] and the solver.
-pub trait PropagatorDefinition: Propagator {
+pub trait PropagatorConfig: Propagator {
 	/// Whether the [`Propagator`] implementation only checks complete
 	/// assignments.
 	///
@@ -194,13 +214,26 @@ pub trait PropagatorDefinition: Propagator {
 	const CHECK_ONLY: bool = false;
 
 	/// The persistence level of the [`Propagator`] implementation's produced
-	/// reasons using [`Propagator::add_reason_clause`].
+	/// reasons using [`Propagator::explain_propagation`].
 	///
 	/// If set to [`ClausePersistence::Forgettable`], then the solver might
 	/// remove the reason clauses to save memory. The [`Propagator`]
 	/// implementation must be able to re-derive the reason clause at a later
 	/// point.
-	const REASON_PERSISTENCE: ClausePersistence = ClausePersistence::Irreduntant;
+	const REASON_PERSISTENCE: ClausePersistence = ClausePersistence::Irredundant;
+}
+
+/// A builder for the reason of an external propagation: the conjunction of
+/// premise literals that together caused a literal to be propagated (see
+/// [`Propagator::explain_propagation`]).
+///
+/// The premises are literals that currently hold. The solver forms the reason
+/// clause by negating each premise and appending the propagated literal, so a
+/// [`Propagator`] must push only the premises; it must not negate them or
+/// include the propagated literal itself.
+#[derive(Debug)]
+pub struct ReasonBuilder<'a> {
+	clause: &'a mut Vec<Lit>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -212,6 +245,19 @@ pub enum SearchDecision {
 	Assign(Lit),
 	/// Force the solver to backtrack to the given decision level.
 	Backtrack(usize),
+}
+
+/// A complete solution found by the solver, handed to
+/// [`Propagator::check_solution`].
+///
+/// The solver must provide the literals sorted by variable, which lets
+/// [`Solution::value`] look up a literal's value with a binary search and
+/// without any allocation.
+#[derive(Clone, Copy, Debug)]
+pub struct Solution<'a> {
+	/// The assigned literals of the observed variables, sorted by variable, as
+	/// provided by the solver.
+	model: &'a [Lit],
 }
 
 /// Actions that a [`Propagator`] can generally undertake when making
@@ -234,4 +280,99 @@ pub trait SolvingActions {
 	/// Remove the default decision phase of the given variable (given as a
 	/// [`Lit`]).
 	fn unphase(&mut self, lit: Lit);
+}
+
+impl<'a> ClauseBuilder<'a> {
+	/// Create a clause builder that appends into the given buffer.
+	pub(crate) fn new(clause: &'a mut Vec<Lit>) -> Self {
+		debug_assert!(
+			clause.is_empty(),
+			"clause does not contain any previous leftovers"
+		);
+		Self { clause }
+	}
+
+	/// Add a literal to the clause.
+	pub fn push(&mut self, lit: Lit) {
+		self.clause.push(lit);
+	}
+
+	/// Reserve capacity for at least `additional` more literals.
+	pub fn reserve(&mut self, additional: usize) {
+		self.clause.reserve(additional);
+	}
+}
+
+impl Extend<Lit> for ClauseBuilder<'_> {
+	fn extend<I: IntoIterator<Item = Lit>>(&mut self, lits: I) {
+		self.clause.extend(lits);
+	}
+}
+
+impl<'a> ReasonBuilder<'a> {
+	/// Create a reason builder that appends premises into the given buffer.
+	pub(crate) fn new(clause: &'a mut Vec<Lit>) -> Self {
+		debug_assert_eq!(
+			clause.len(),
+			1,
+			"clause is prefilled with the literal to be explained"
+		);
+		Self { clause }
+	}
+
+	/// Add a premise literal (a literal that currently holds) to the reason.
+	pub fn push(&mut self, premise: Lit) {
+		self.clause.push(!premise);
+	}
+
+	/// Reserve capacity for at least `additional` more premise literals.
+	pub fn reserve(&mut self, additional: usize) {
+		self.clause.reserve(additional);
+	}
+}
+
+impl Extend<Lit> for ReasonBuilder<'_> {
+	fn extend<I: IntoIterator<Item = Lit>>(&mut self, premises: I) {
+		self.clause.extend(premises.into_iter().map(|l| !l));
+	}
+}
+
+impl<'a> Solution<'a> {
+	/// The assigned literals of the observed variables, in order of their
+	/// variable.
+	pub fn literals(&self) -> &'a [Lit] {
+		self.model
+	}
+
+	/// Creates a solution view over the model literals provided by the solver.
+	///
+	/// The literals must be sorted by variable, as the solver provides them;
+	/// [`Solution::value`] relies on this ordering.
+	pub(crate) fn new(model: &'a [Lit]) -> Self {
+		debug_assert!(
+			model.windows(2).all(|w| w[0].var() < w[1].var()),
+			"the solver must provide the model sorted by (distinct) variable"
+		);
+		Self { model }
+	}
+
+	/// Returns the truth value of `lit` in the solution.
+	///
+	/// The literal's variable must be observed by the propagator, and hence be
+	/// part of the solution. Querying any other variable is a usage error that
+	/// is caught by a debug assertion and otherwise treated as `false`.
+	pub fn value(&self, lit: Lit) -> bool {
+		match self
+			.model
+			.binary_search_by(|assigned| assigned.var().cmp(&lit.var()))
+		{
+			Ok(i) => self.model[i] == lit,
+			Err(_) => {
+				// A literal absent from the model belongs to a variable that is not
+				// observed by the propagator, which it should therefore not query.
+				debug_assert!(false, "queried an unobserved variable");
+				false
+			}
+		}
+	}
 }


### PR DESCRIPTION
Propagators previously returned a freshly allocated `Vec` for each
yielded clause. Under deep search this produced large allocation churn.
The propagator now writes its literals into a solver-owned, reusable
clause buffer through `ReasonBuilder`/`ClauseBuilder`, removing the
need for per-clause allocations.

While reworking the API:

- Rename the callbacks to `explain_propagation` (was `add_reason`) and
  `provide_clause` (was `add_external_clause`) to better describe their
  role.
- Rename `PropagatorDefinition`/`ProofTracerDefinition` to
  `PropagatorConfig`/`ProofTracerConfig`.
- Replace `check_solution`'s `&dyn Valuation` argument with a borrowed
  `Solution` view that looks values up via a binary search over the
  model, avoiding the per-call `HashMap` construction.
- Make `Lit` `#[repr(transparent)]` so the solver's model can be
  reinterpreted as `&[Lit]` without copying.
- Use a single buffer for the reason and the external clause in the
  IPASIR-UP bridge, since the two cannot be yielded simultaneously.
- Fix the `ClausePersistence::Irredundant` spelling and the stale
  `propagate` doc comment.
