### PR TITLE
build(pyndakaas): build a single abi3 wheel per platform

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,7 +46,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path crates/pyndakaas/Cargo.toml
+          args: --release --out dist --manifest-path crates/pyndakaas/Cargo.toml
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
       - name: Upload wheels
@@ -109,7 +109,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path crates/pyndakaas/Cargo.toml
+          args: --release --out dist --manifest-path crates/pyndakaas/Cargo.toml
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -172,7 +172,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path crates/pyndakaas/Cargo.toml
+          args: --release --out dist --manifest-path crates/pyndakaas/Cargo.toml
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v7
@@ -210,7 +210,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path crates/pyndakaas/Cargo.toml
+          args: --release --out dist --manifest-path crates/pyndakaas/Cargo.toml
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v7

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 [dependencies]
 itertools = "0.15"
 pindakaas = { version = "0.5.1", path = "../pindakaas", features = ["kissat"] }
-pyo3 = "0.29.0"
+pyo3 = { version = "0.29.0", features = ["abi3-py39"] }
 
 [lints]
 workspace = true

--- a/crates/pyndakaas/pyproject.toml
+++ b/crates/pyndakaas/pyproject.toml
@@ -28,13 +28,13 @@ classifiers = [
 	"Topic :: Scientific/Engineering :: Artificial Intelligence",
 	"Topic :: Scientific/Engineering :: Mathematics",
 	"Programming Language :: Python :: Implementation :: CPython",
-	"Programming Language :: Python :: Implementation :: PyPy",
 	"Programming Language :: Python :: 3",
 	"Programming Language :: Python :: 3.9",
 	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
 	"Programming Language :: Python :: 3.12",
 	"Programming Language :: Python :: 3.13",
+	"Programming Language :: Python :: 3.14",
 ]
 dynamic = ["version"]
 

--- a/crates/pyndakaas/python/tests/test_solving.py
+++ b/crates/pyndakaas/python/tests/test_solving.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import pindakaas
 
 
@@ -57,3 +59,12 @@ def test_issue_159():
 def test_set_option():
     slv = pindakaas.solver.CaDiCaL()
     slv._set_option("factor", 0)
+
+
+def test_time_limit():
+    # timedelta -> Duration takes a different code path under the limited API
+    slv = pindakaas.solver.CaDiCaL()
+    x, y = slv.new_vars(2)
+    slv.add_clause([x, y])
+    with slv.solve(time_limit=timedelta(seconds=10)) as result:
+        assert result.status == pindakaas.solver.Status.SATISFIED


### PR DESCRIPTION
Enable pyo3's abi3-py39 feature so one wheel per platform works on every
CPython >= 3.9, instead of one wheel per interpreter version. Drops
--find-interpreter from the CI build jobs, where it is a no-op under abi3
and would only be misleading on the cross-compiled targets, which no longer
need an interpreter present at all. PyPy no longer gets binary wheels,
since abi3 does not apply to it; its classifier is dropped and it installs
from the sdist.

Takes a release from ~60-100 wheels down to 15 + sdist, and lets new CPython
releases work without a rebuild.
