### PR TITLE
chore: release

### DIFF
--- a/crates/pindakaas-cadical/CHANGELOG.md
+++ b/crates/pindakaas-cadical/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.4.0...pindakaas-cadical-v0.4.1) - 2026-08-06
+
+### Fixed
+
+- C robustness issues
+
 ## [0.4.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.3.2...pindakaas-cadical-v0.4.0) - 2026-06-09
 
 ### Added

--- a/crates/pindakaas-cadical/Cargo.toml
+++ b/crates/pindakaas-cadical/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-cadical"
 description = "build of the Cadical SAT solver for the pindakaas crate"
-version = "0.4.0"
+version = "0.4.1"
 license = "MIT"
 
 include = [

--- a/crates/pindakaas-intel-sat/CHANGELOG.md
+++ b/crates/pindakaas-intel-sat/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-intel-sat-v0.2.0...pindakaas-intel-sat-v0.2.1) - 2026-08-06
+
+### Fixed
+
+- C robustness issues
+
 ## [0.2.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-intel-sat-v0.1.0...pindakaas-intel-sat-v0.2.0) - 2025-09-25
 
 ### Added

--- a/crates/pindakaas-intel-sat/Cargo.toml
+++ b/crates/pindakaas-intel-sat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-intel-sat"
 description = "build of the Intel SAT solver for the pindakaas crate"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 
 build = "build.rs"

--- a/crates/pindakaas-kissat/CHANGELOG.md
+++ b/crates/pindakaas-kissat/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.2...pindakaas-kissat-v0.2.3) - 2026-08-06
+
+### Fixed
+
+- C robustness issues
+
 ## [0.2.2](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.1...pindakaas-kissat-v0.2.2) - 2026-02-21
 
 ### Added

--- a/crates/pindakaas-kissat/Cargo.toml
+++ b/crates/pindakaas-kissat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-kissat"
 description = "build of the Kissat SAT solver for the pindakaas crate"
-version = "0.2.2"
+version = "0.2.3"
 license = "MIT"
 
 build = "build.rs"

--- a/crates/pindakaas/CHANGELOG.md
+++ b/crates/pindakaas/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.5.1...pindakaas-v0.6.0) - 2026-08-06
+
+### Added
+
+- use declared bounds of log encodings during aggregation
+- apply greatest common divisor during linear aggregation
+- *(external-propagation)* streamline allocation in ExternalPropagation API
+
+### Fixed
+
+- re-enable already working testcases
+- C robustness issues
+
+### Other
+
+- clean up linear aggregation
+- *(external-propagation)* remove ReasonBuilder
+- update itertools from 0.14 to 0.15
+
 ## [0.5.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.5.0...pindakaas-v0.5.1) - 2026-06-09
 
 ### Added

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas"
 description = "Encoding Integer and Pseudo Boolean constraints into CNF"
-version = "0.5.1"
+version = "0.6.0"
 
 authors.workspace = true
 edition.workspace = true
@@ -27,9 +27,9 @@ libloading = { version = "0.9", optional = true }
 tracing = { workspace = true, optional = true }
 
 # Optional Solver Interfaces
-pindakaas-cadical = { version = "0.4.0", path = "../pindakaas-cadical", optional = true }
-pindakaas-intel-sat = { version = "0.2.0", path = "../pindakaas-intel-sat", optional = true }
-pindakaas-kissat = { version = "0.2.2", path = "../pindakaas-kissat", optional = true }
+pindakaas-cadical = { version = "0.4.1", path = "../pindakaas-cadical", optional = true }
+pindakaas-intel-sat = { version = "0.2.1", path = "../pindakaas-intel-sat", optional = true }
+pindakaas-kissat = { version = "0.2.3", path = "../pindakaas-kissat", optional = true }
 splr = { version = "0.17", optional = true }
 
 [dev-dependencies]

--- a/crates/pindakaas/src/bool_linear.rs
+++ b/crates/pindakaas/src/bool_linear.rs
@@ -873,14 +873,16 @@ impl BoolLinAggregator {
 							// this term will cancel out later when we add q*min_lit to the LHS
 							let _ = terms.remove(min_index);
 
-							// since y + x1 + x2 + ... = 1 (exactly-one), we have q*y + q*x1 + q*x2 + ... = q
-							// after adding term 0*y, we can add q*y + q*x1 + q*x2 + ... on the LHS, and q on the RHS
+							// since y + x1 + x2 + ... = 1 (exactly-one), we have q*y + q*x1 + q*x2
+							// + ... = q after adding term 0*y, we can add q*y + q*x1 + q*x2
+							// + ... on the LHS, and q on the RHS
 							terms.push((y, 0)); // note: it's fine to add y into the same AMO group
 							terms = terms.iter().map(|(lit, coef)| (*lit, *coef + q)).collect();
 							k += q;
 						}
 
-						// all coefficients should be positive (since we subtracted the most negative coefficient)
+						// all coefficients should be positive (since we subtracted the most
+						// negative coefficient)
 						vec![Part::Amo(
 							terms
 								.into_iter()
@@ -890,7 +892,8 @@ impl BoolLinAggregator {
 					}
 
 					(Constraint::ImplicationChain, terms) => {
-						// normalize by splitting up the chain into two chains by coef polarity, inverting the coefs of the neg
+						// normalize by splitting up the chain into two chains by coef polarity,
+						// inverting the coefs of the neg
 						let (pos_chain, neg_chain): (_, Vec<_>) =
 							terms.into_iter().partition(|(_, coef)| coef.is_positive());
 						vec![
@@ -1056,10 +1059,19 @@ impl BoolLinAggregator {
 			partition
 				.iter()
 				.map(|part| match part {
+					// Only a single literal of the group can be true.
 					Part::Amo(terms) => terms.iter().map(|&(_, i)| *i).max().unwrap_or(0),
-					Part::Ic(terms) | Part::Dom(terms, _, _) => {
-						terms.iter().map(|&(_, coef)| *coef).sum()
-						// TODO max(k, acc + ..)
+					// Every literal of the chain can be true at the same time.
+					Part::Ic(terms) => terms.iter().map(|&(_, coef)| *coef).sum(),
+					// The group is known to stay within its declared bounds, which
+					// can be tighter than the sum of its coefficients.
+					Part::Dom(terms, _, u) => {
+						debug_assert!(
+							**u <= terms.iter().map(|&(_, coef)| *coef).sum(),
+							"upper bound {u:?} of a domain group exceeds the sum of \
+							 its coefficients, so it cannot be used as a bound here"
+						);
+						**u
 					}
 				})
 				.sum(),
@@ -1234,12 +1246,28 @@ impl BoolLinExp {
 	// Probably makes more sense to use something like int encodings
 	/// Add a log encoding to the linear expression, where it is given that the
 	/// log encoding is known to be within `lb..=ub`.
+	///
+	/// Note that `lb` and `ub` bound the integer that the terms encode, not the
+	/// value the terms contribute to the expression. For terms `(x₀, c)`,
+	/// `(x₁, 2c)`, `(x₂, 4c)`, a bound of `0..=3` means the contribution is at
+	/// most `3c`.
 	pub fn add_bounded_log_encoding(
 		mut self,
 		terms: &[(Lit, Coeff)],
 		lb: Coeff,
 		ub: Coeff,
 	) -> Self {
+		debug_assert!(
+			lb <= ub,
+			"lower bound {lb} of a log encoding exceeds its upper bound {ub}"
+		);
+		debug_assert!(
+			terms.is_empty()
+				|| (lb >= 0
+					&& terms[0].1.abs().saturating_mul(ub)
+						<= terms.iter().map(|(_, coef)| coef.abs()).sum::<Coeff>()),
+			"bounds {lb}..={ub} lie outside the range the given terms can represent"
+		);
 		self.constraints
 			.push((Constraint::Domain { lb, ub }, terms.len()));
 		self.terms.extend(terms.iter().cloned());
@@ -3054,7 +3082,9 @@ mod tests {
 			}))
 		);
 
-		// Correctly account for the coefficient in the Dom bounds
+		// The declared upper bound of the group, rather than the sum of its
+		// coefficients, decides whether the constraint can still be violated. The
+		// group is known to be at most 3, so it can never exceed 5.
 		let mut cnf = Cnf::default();
 		let (a, b, c) = cnf.new_lits();
 		assert_eq!(
@@ -3062,6 +3092,21 @@ mod tests {
 				&mut cnf,
 				&BoolLinear::new(
 					BoolLinExp::default().add_bounded_log_encoding(&[(a, 1), (b, 2), (c, 4)], 0, 3),
+					Comparator::LessEq,
+					5,
+				)
+			),
+			Ok(BoolLinVariant::Trivial)
+		);
+
+		// Raising the bound above `k` leaves a constraint that must be encoded
+		let mut cnf = Cnf::default();
+		let (a, b, c) = cnf.new_lits();
+		assert_eq!(
+			BoolLinAggregator::default().aggregate(
+				&mut cnf,
+				&BoolLinear::new(
+					BoolLinExp::default().add_bounded_log_encoding(&[(a, 1), (b, 2), (c, 4)], 0, 6),
 					Comparator::LessEq,
 					5,
 				)
@@ -3074,11 +3119,32 @@ mod tests {
 						(c, PosCoeff::new(4))
 					],
 					PosCoeff::new(0),
-					PosCoeff::new(7)
+					PosCoeff::new(6)
 				),],
 				cmp: LimitComp::LessEq,
 				k: PosCoeff::new(5),
 			}))
+		);
+
+		// Dropping the most significant term lowers the value the group can still
+		// reach, so its upper bound is re-clamped to what is left. Here 8d cannot
+		// be true, and the remaining bits cannot exceed 7 either.
+		let mut cnf = Cnf::default();
+		let (a, b, c, d) = cnf.new_lits();
+		assert_eq!(
+			BoolLinAggregator::default().aggregate(
+				&mut cnf,
+				&BoolLinear::new(
+					BoolLinExp::default().add_bounded_log_encoding(
+						&[(a, 1), (b, 2), (c, 4), (d, 8)],
+						0,
+						15
+					),
+					Comparator::LessEq,
+					7,
+				)
+			),
+			Ok(BoolLinVariant::Trivial)
 		);
 
 		// Correctly convert GreaterEq into LessEq with side constrains

--- a/crates/pindakaas/src/bool_linear.rs
+++ b/crates/pindakaas/src/bool_linear.rs
@@ -37,7 +37,7 @@ use crate::{
 	propositional_logic::{Formula, TseitinEncoder},
 	sorted::{Sorted, SortedEncoder},
 	BoolVal, Checker, ClauseDatabase, ClauseDatabaseTools, Coeff, Encoder, IntEncoding, Lit,
-	Result, Unsatisfiable, Valuation, Var,
+	Result, Unsatisfiable, Valuation,
 };
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -807,11 +807,10 @@ impl BoolLinAggregator {
 			}
 		}
 
-		// Add remaining (unconstrained) terms
+		// Add remaining (unconstrained) terms.
 		debug_assert!(agg.len() <= lin.exp.num_free);
-		let agg_keys: Vec<Var> = agg.keys().copied().sorted().collect();
-		for var in agg_keys {
-			partition.push((Constraint::AtMostOne, vec![(var.into(), agg[&var])]));
+		for (var, coef) in agg.into_iter().sorted_by_key(|&(var, _)| var) {
+			partition.push((Constraint::AtMostOne, vec![(var.into(), coef)]));
 		}
 
 		k -= lin.exp.add;
@@ -841,7 +840,6 @@ impl BoolLinAggregator {
 							return vec![Part::Amo(
 								terms
 									.into_iter()
-									.filter(|&(_, coef)| coef != 0)
 									.map(|(lit, coef)| {
 										convert_term_if_negative((lit, coef), &mut k)
 									})
@@ -864,29 +862,21 @@ impl BoolLinAggregator {
 							let y = db.new_lit();
 
 							// ~x1 /\ ~x2 /\ .. -> y == x1 \/ x2 \/ .. \/ y
-							db.add_clause(
-								terms
-									.iter()
-									.map(|(lit, _)| *lit)
-									.chain(once(y))
-							)
-							.unwrap();
+							db.add_clause(terms.iter().map(|(lit, _)| *lit).chain(once(y)))
+								.unwrap();
 
-														// y -> ( ~x1 /\ ~x2 /\ .. ) == ~y \/ ~x1, ~y \/ ~x2, ..
+							// y -> ( ~x1 /\ ~x2 /\ .. ) == ~y \/ ~x1, ~y \/ ~x2, ..
 							for lit in terms.iter().map(|tup| tup.0) {
-								db.add_clause( [!y, !lit]).unwrap();
+								db.add_clause([!y, !lit]).unwrap();
 							}
 
 							// this term will cancel out later when we add q*min_lit to the LHS
-							let _ =terms.remove(min_index);
+							let _ = terms.remove(min_index);
 
 							// since y + x1 + x2 + ... = 1 (exactly-one), we have q*y + q*x1 + q*x2 + ... = q
 							// after adding term 0*y, we can add q*y + q*x1 + q*x2 + ... on the LHS, and q on the RHS
 							terms.push((y, 0)); // note: it's fine to add y into the same AMO group
-							terms = terms
-								.iter()
-								.map(|(lit, coef)| (*lit, *coef + q))
-								.collect();
+							terms = terms.iter().map(|(lit, coef)| (*lit, *coef + q)).collect();
 							k += q;
 						}
 
@@ -921,11 +911,12 @@ impl BoolLinAggregator {
 							),
 						]
 					}
-					(Constraint::Domain { lb: l, ub: u },  terms) => {
+					(Constraint::Domain { lb: l, ub: u }, terms) => {
 						assert!(
-							terms.iter().all(|(_,coef)| coef.is_positive())
-								|| terms.iter().all(|(_,coef)| coef.is_negative()),
-																"Normalizing mixed positive/negative coefficients not yet supported for Dom constraint on {terms:?}"
+							terms.iter().all(|(_, coef)| coef.is_positive())
+								|| terms.iter().all(|(_, coef)| coef.is_negative()),
+							"Normalizing mixed positive/negative coefficients not yet \
+							 supported for Dom constraint on {terms:?}"
 						);
 						vec![Part::Dom(
 							terms
@@ -940,12 +931,10 @@ impl BoolLinAggregator {
 			})
 			.map(|part| {
 				// This step has to come *after* Amo normalization
-				let filter_zero_coefficients = |terms: Vec<(Lit, PosCoeff)>| -> Vec<(Lit, PosCoeff)> {
-					terms
-						.into_iter()
-						.filter(|&(_, coef)| *coef != 0)
-						.collect()
-				};
+				let filter_zero_coefficients =
+					|terms: Vec<(Lit, PosCoeff)>| -> Vec<(Lit, PosCoeff)> {
+						terms.into_iter().filter(|&(_, coef)| *coef != 0).collect()
+					};
 
 				match part {
 					Part::Amo(terms) => Part::Amo(filter_zero_coefficients(terms)),
@@ -2498,6 +2487,29 @@ mod tests {
 			Ok(BoolLinVariant::CardinalityOne(CardinalityOne {
 				lits: vec![!a, !b, !c],
 				cmp: LimitComp::LessEq,
+			}))
+		);
+	}
+
+	#[test]
+	fn aggregator_zero_coefficient() {
+		let mut cnf = Cnf::default();
+		let (a, b, c, d) = cnf.new_lits();
+		// A term that cannot contribute to the sum is dropped entirely, rather
+		// than kept with a coefficient of zero
+		assert_eq!(
+			BoolLinAggregator::default().aggregate(
+				&mut cnf,
+				&BoolLinear::new(
+					BoolLinExp::from_slices(&[0, 2, 3, 4], &[a, b, c, d]),
+					Comparator::LessEq,
+					8
+				)
+			),
+			Ok(BoolLinVariant::Linear(NormalizedBoolLinear {
+				terms: construct_terms(&[(b, 2), (c, 3), (d, 4)]),
+				cmp: LimitComp::LessEq,
+				k: PosCoeff::new(8)
 			}))
 		);
 	}

--- a/crates/pindakaas/src/bool_linear.rs
+++ b/crates/pindakaas/src/bool_linear.rs
@@ -973,7 +973,7 @@ impl BoolLinAggregator {
 		let mut k = PosCoeff::new(k);
 
 		// Remove terms with coefs higher than k
-		let partition = partition
+		let mut partition = partition
 			.into_iter()
 			.map(|part| match part {
 				Part::Amo(terms) => Part::Amo(
@@ -1028,6 +1028,39 @@ impl BoolLinAggregator {
 			})
 			.filter(|part| part.iter().next().is_some()) // filter out empty groups
 			.collect_vec();
+
+		// Normalize the constraint by the greatest common divisor of its
+		// coefficients, shrinking both the coefficients and `k` for every encoder
+		// downstream.
+		let mut divisor = 0;
+		for coef in partition
+			.iter()
+			.flat_map(|part| part.iter())
+			.map(|&(_, coef)| coef.0)
+		{
+			// Seeding the divisor with zero lets the first coefficient fall out of
+			// the same loop, since gcd(0, c) is c.
+			let mut other = coef;
+			while other != 0 {
+				(divisor, other) = (other, divisor % other);
+			}
+			if divisor == 1 {
+				break;
+			}
+		}
+		if divisor > 1 {
+			// The left hand side can only take on multiples of the divisor, so an
+			// equality that does not sit on one of those multiples is unsatisfiable.
+			if cmp == LimitComp::Equal && *k % divisor != 0 {
+				db.contradiction()?;
+				unreachable!();
+			}
+			for part in &mut partition {
+				part.div_assign(divisor);
+			}
+			// Rounding down is sound for `≤` for the same reason.
+			k = PosCoeff::new(*k / divisor);
+		}
 
 		// Check whether some literals can violate / satisfy the constraint
 		let lhs_ub = PosCoeff::new(
@@ -1099,25 +1132,13 @@ impl BoolLinAggregator {
 			.next()
 			.is_some());
 
-		// special case: all coefficients are equal (and can be made one)
-		let val = partition
-			.iter()
-			.flat_map(|part| part.iter().map(|&(_, coef)| coef))
-			.next()
-			.unwrap();
-
+		// special case: all coefficients are equal, which the normalization above
+		// will have reduced to one
 		if partition
 			.iter()
 			.flat_map(|part| part.iter())
-			.all(|&(_, coef)| coef == val)
+			.all(|&(_, coef)| *coef == 1)
 		{
-			// trivial case: k cannot be made from the coefficients
-			if cmp == LimitComp::Equal && *k % *val != 0 {
-				db.contradiction()?;
-				unreachable!();
-			}
-
-			k = PosCoeff::new(*k / *val);
 			let partition = partition
 				.iter()
 				.flat_map(|part| part.iter())
@@ -1876,6 +1897,33 @@ impl From<CardinalityOne> for NormalizedBoolLinear {
 }
 
 impl Part {
+	/// Divide every coefficient in the part, and any domain bounds it carries,
+	/// by `g`.
+	///
+	/// The caller is required to ensure that `g` divides each of these values
+	/// exactly.
+	pub(crate) fn div_assign(&mut self, g: Coeff) {
+		let terms = match self {
+			Part::Amo(terms) | Part::Ic(terms) => terms,
+			Part::Dom(terms, lb, ub) => {
+				debug_assert!(
+					**lb % g == 0 && **ub % g == 0,
+					"domain bounds {lb}..{ub} are not divisible by {g}"
+				);
+				**lb /= g;
+				**ub /= g;
+				terms
+			}
+		};
+		for (_, coef) in terms {
+			debug_assert!(
+				**coef % g == 0,
+				"coefficient {coef} is not divisible by {g}"
+			);
+			**coef /= g;
+		}
+	}
+
 	pub(crate) fn iter(&self) -> impl Iterator<Item = &(Lit, PosCoeff)> {
 		self.into_iter()
 	}
@@ -2450,6 +2498,101 @@ mod tests {
 			Ok(BoolLinVariant::CardinalityOne(CardinalityOne {
 				lits: vec![!a, !b, !c],
 				cmp: LimitComp::LessEq,
+			}))
+		);
+	}
+
+	#[test]
+	fn aggregator_gcd() {
+		let mut cnf = Cnf::default();
+		let (a, b, c) = cnf.new_lits();
+		// 2a + 4b + 6c ≤ 7 is divided by 2, rounding the right hand side down
+		assert_eq!(
+			BoolLinAggregator::default().aggregate(
+				&mut cnf,
+				&BoolLinear::new(
+					BoolLinExp::from_slices(&[2, 4, 6], &[a, b, c]),
+					Comparator::LessEq,
+					7
+				)
+			),
+			Ok(BoolLinVariant::Linear(NormalizedBoolLinear {
+				terms: construct_terms(&[(a, 1), (b, 2), (c, 3)]),
+				cmp: LimitComp::LessEq,
+				k: PosCoeff::new(3)
+			}))
+		);
+
+		// An equality that does not sit on a multiple of the divisor is
+		// unsatisfiable
+		let mut cnf = Cnf::default();
+		let (a, b) = cnf.new_lits();
+		assert_eq!(
+			BoolLinAggregator::default().aggregate(
+				&mut cnf,
+				&BoolLinear::new(
+					BoolLinExp::from_slices(&[2, 4], &[a, b]),
+					Comparator::Equal,
+					5
+				)
+			),
+			Err(Unsatisfiable)
+		);
+
+		// Dropping terms whose coefficient exceeds k can leave behind a set of
+		// coefficients with a larger common divisor than the constraint started
+		// with, which is why normalization runs after that step. Here
+		// gcd(3, 3, 3, 7) is 1, but once 7d is dropped the rest divides by 3,
+		// leaving `a + b + c ≤ 1`.
+		let mut cnf = Cnf::default();
+		let (a, b, c, d) = cnf.new_lits();
+		assert_eq!(
+			BoolLinAggregator::default().aggregate(
+				&mut cnf,
+				&BoolLinear::new(
+					BoolLinExp::from_slices(&[3, 3, 3, 7], &[a, b, c, d]),
+					Comparator::LessEq,
+					5
+				)
+			),
+			Ok(BoolLinVariant::CardinalityOne(CardinalityOne {
+				lits: vec![a, b, c],
+				cmp: LimitComp::LessEq,
+			}))
+		);
+
+		// The same under `=`: once 7d is dropped the remaining sum can only reach
+		// multiples of 3, so it can never equal 5.
+		let mut cnf = Cnf::default();
+		let (a, b, c, d) = cnf.new_lits();
+		assert_eq!(
+			BoolLinAggregator::default().aggregate(
+				&mut cnf,
+				&BoolLinear::new(
+					BoolLinExp::from_slices(&[3, 3, 3, 7], &[a, b, c, d]),
+					Comparator::Equal,
+					5
+				)
+			),
+			Err(Unsatisfiable)
+		);
+
+		// Coprime coefficients are left untouched
+		let mut cnf = Cnf::default();
+		let (a, b, c) = cnf.new_lits();
+		assert_eq!(
+			BoolLinAggregator::default().aggregate(
+				&mut cnf,
+				&BoolLinear::new(
+					BoolLinExp::from_slices(&[2, 3, 4], &[a, b, c]),
+					Comparator::LessEq,
+					7
+				)
+			),
+			Ok(BoolLinVariant::Linear(NormalizedBoolLinear {
+				terms: construct_terms(&[(a, 2), (b, 3), (c, 4)]),
+				cmp: LimitComp::LessEq,
+				k: PosCoeff::new(7)
 			}))
 		);
 	}

--- a/crates/pyndakaas/CHANGELOG.md
+++ b/crates/pyndakaas/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.5.1...pyndakaas-v0.5.2) - 2026-08-06
+
+### Fixed
+
+- C robustness issues
+
+### Other
+
+- *(pyndakaas)* build a single abi3 wheel per platform
+- update itertools from 0.14 to 0.15
+- *(deps)* update pyo3 requirement from 0.28.3 to 0.29.0
+
 ## [0.5.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.5.0...pyndakaas-v0.5.1) - 2026-06-09
 
 ### Other

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyndakaas"
 description = "Python bindings for the pindakaas crate"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 authors.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.15"
-pindakaas = { version = "0.5.1", path = "../pindakaas", features = ["kissat"] }
+pindakaas = { version = "0.6.0", path = "../pindakaas", features = ["kissat"] }
 pyo3 = { version = "0.29.0", features = ["abi3-py39"] }
 
 [lints]


### PR DESCRIPTION



## 🤖 New release

* `pindakaas-cadical`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `pindakaas-intel-sat`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `pindakaas-kissat`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `pindakaas`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `pyndakaas`: 0.5.1 -> 0.5.2

### ⚠ `pindakaas` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ClausePersistence:Irredundant in /tmp/.tmpRjiPrI/pindakaas/crates/pindakaas/src/solver/propagation.rs:24

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ClausePersistence::Irreduntant, previously in file /tmp/.tmp5IVRzp/pindakaas/src/solver/propagation.rs:17

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_missing.ron

Failed in:
  method add_external_clause of trait Propagator, previously in file /tmp/.tmp5IVRzp/pindakaas/src/solver/propagation.rs:121
  method add_reason_clause of trait Propagator, previously in file /tmp/.tmp5IVRzp/pindakaas/src/solver/propagation.rs:132

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait pindakaas::solver::propagation::PropagatorDefinition, previously in file /tmp/.tmp5IVRzp/pindakaas/src/solver/propagation.rs:188
  trait pindakaas::solver::cadical::ProofTracerDefinition, previously in file /tmp/.tmp5IVRzp/pindakaas/src/solver/cadical.rs:193
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pindakaas-cadical`

<blockquote>

## [0.4.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.4.0...pindakaas-cadical-v0.4.1) - 2026-08-06

### Fixed

- C robustness issues
</blockquote>

## `pindakaas-intel-sat`

<blockquote>

## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-intel-sat-v0.2.0...pindakaas-intel-sat-v0.2.1) - 2026-08-06

### Fixed

- C robustness issues
</blockquote>

## `pindakaas-kissat`

<blockquote>

## [0.2.3](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.2...pindakaas-kissat-v0.2.3) - 2026-08-06

### Fixed

- C robustness issues
</blockquote>

## `pindakaas`

<blockquote>

## [0.6.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.5.1...pindakaas-v0.6.0) - 2026-08-06

### Added

- use declared bounds of log encodings during aggregation
- apply greatest common divisor during linear aggregation
- *(external-propagation)* streamline allocation in ExternalPropagation API

### Fixed

- re-enable already working testcases
- C robustness issues

### Other

- clean up linear aggregation
- *(external-propagation)* remove ReasonBuilder
- update itertools from 0.14 to 0.15
</blockquote>

## `pyndakaas`

<blockquote>

## [0.5.2](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.5.1...pyndakaas-v0.5.2) - 2026-08-06

### Fixed

- C robustness issues

### Other

- *(pyndakaas)* build a single abi3 wheel per platform
- update itertools from 0.14 to 0.15
- *(deps)* update pyo3 requirement from 0.28.3 to 0.29.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).