### PR TITLE
chore: release

### DIFF
--- a/crates/pindakaas-cadical/CHANGELOG.md
+++ b/crates/pindakaas-cadical/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.4.0...pindakaas-cadical-v0.4.1) - 2026-08-07
+
+### Fixed
+
+- C robustness issues
+
+### Other
+
+- update CaDiCaL to 3.0.1
+
 ## [0.4.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.3.2...pindakaas-cadical-v0.4.0) - 2026-06-09
 
 ### Added

--- a/crates/pindakaas-cadical/Cargo.toml
+++ b/crates/pindakaas-cadical/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-cadical"
 description = "build of the Cadical SAT solver for the pindakaas crate"
-version = "0.4.0"
+version = "0.4.1"
 license = "MIT"
 
 include = [

--- a/crates/pindakaas-intel-sat/CHANGELOG.md
+++ b/crates/pindakaas-intel-sat/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-intel-sat-v0.2.0...pindakaas-intel-sat-v0.2.1) - 2026-08-07
+
+### Fixed
+
+- C robustness issues
+
 ## [0.2.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-intel-sat-v0.1.0...pindakaas-intel-sat-v0.2.0) - 2025-09-25
 
 ### Added

--- a/crates/pindakaas-intel-sat/Cargo.toml
+++ b/crates/pindakaas-intel-sat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-intel-sat"
 description = "build of the Intel SAT solver for the pindakaas crate"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 
 build = "build.rs"

--- a/crates/pindakaas-kissat/CHANGELOG.md
+++ b/crates/pindakaas-kissat/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.2...pindakaas-kissat-v0.2.3) - 2026-08-07
+
+### Fixed
+
+- C robustness issues
+
 ## [0.2.2](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.1...pindakaas-kissat-v0.2.2) - 2026-02-21
 
 ### Added

--- a/crates/pindakaas-kissat/Cargo.toml
+++ b/crates/pindakaas-kissat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas-kissat"
 description = "build of the Kissat SAT solver for the pindakaas crate"
-version = "0.2.2"
+version = "0.2.3"
 license = "MIT"
 
 build = "build.rs"

--- a/crates/pindakaas/CHANGELOG.md
+++ b/crates/pindakaas/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.5.1...pindakaas-v0.6.0) - 2026-08-07
+
+### Added
+
+- add product encoding for at-most-one constraints
+- use declared bounds of log encodings during aggregation
+- apply greatest common divisor during linear aggregation
+- *(external-propagation)* streamline allocation in ExternalPropagation API
+
+### Fixed
+
+- imply upper bound for groups of mutually exclusive terms
+- re-enable already working testcases
+- C robustness issues
+
+### Other
+
+- tie the product encoding's selectors to their literals
+- drop the fixed literals from the ladder encoding
+- clean up linear aggregation
+- *(external-propagation)* remove ReasonBuilder
+- update itertools from 0.14 to 0.15
+
 ## [0.5.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.5.0...pindakaas-v0.5.1) - 2026-06-09
 
 ### Added

--- a/crates/pindakaas/Cargo.toml
+++ b/crates/pindakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pindakaas"
 description = "Encoding Integer and Pseudo Boolean constraints into CNF"
-version = "0.5.1"
+version = "0.6.0"
 
 authors.workspace = true
 edition.workspace = true
@@ -27,9 +27,9 @@ libloading = { version = "0.9", optional = true }
 tracing = { workspace = true, optional = true }
 
 # Optional Solver Interfaces
-pindakaas-cadical = { version = "0.4.0", path = "../pindakaas-cadical", optional = true }
-pindakaas-intel-sat = { version = "0.2.0", path = "../pindakaas-intel-sat", optional = true }
-pindakaas-kissat = { version = "0.2.2", path = "../pindakaas-kissat", optional = true }
+pindakaas-cadical = { version = "0.4.1", path = "../pindakaas-cadical", optional = true }
+pindakaas-intel-sat = { version = "0.2.1", path = "../pindakaas-intel-sat", optional = true }
+pindakaas-kissat = { version = "0.2.3", path = "../pindakaas-kissat", optional = true }
 splr = { version = "0.17", optional = true }
 
 [dev-dependencies]

--- a/crates/pyndakaas/CHANGELOG.md
+++ b/crates/pyndakaas/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.5.1...pyndakaas-v0.5.2) - 2026-08-07
+
+### Added
+
+- add product encoding for at-most-one constraints
+
+### Fixed
+
+- C robustness issues
+
+### Other
+
+- *(pyndakaas)* build a single abi3 wheel per platform
+- update itertools from 0.14 to 0.15
+- *(deps)* update pyo3 requirement from 0.28.3 to 0.29.0
+
 ## [0.5.1](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.5.0...pyndakaas-v0.5.1) - 2026-06-09
 
 ### Other

--- a/crates/pyndakaas/Cargo.toml
+++ b/crates/pyndakaas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyndakaas"
 description = "Python bindings for the pindakaas crate"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 authors.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.15"
-pindakaas = { version = "0.5.1", path = "../pindakaas", features = ["kissat"] }
+pindakaas = { version = "0.6.0", path = "../pindakaas", features = ["kissat"] }
 pyo3 = { version = "0.29.0", features = ["abi3-py39"] }
 
 [lints]


### PR DESCRIPTION



## 🤖 New release

* `pindakaas-cadical`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `pindakaas-intel-sat`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `pindakaas-kissat`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `pindakaas`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `pyndakaas`: 0.5.1 -> 0.6.0

### ⚠ `pindakaas` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_missing.ron

Failed in:
  enum pindakaas::bool_linear::BoolLinVariant, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/bool_linear.rs:97
  enum pindakaas::IntEncoding, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/lib.rs:552
  enum pindakaas::bool_linear::Comparator, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/bool_linear.rs:134
  enum pindakaas::propositional_logic::Formula, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/propositional_logic.rs:21

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_added.ron

Failed in:
  variant ClausePersistence:Irredundant in /tmp/.tmpMhdON0/pindakaas/crates/pindakaas/src/solver/propagation.rs:27

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ClausePersistence::Irreduntant, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/solver/propagation.rs:17

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/module_missing.ron

Failed in:
  mod pindakaas::cardinality, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/cardinality.rs:1
  mod pindakaas::propositional_logic, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/propositional_logic.rs:1
  mod pindakaas::cardinality_one, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/cardinality_one.rs:1
  mod pindakaas::bool_linear, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/bool_linear.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/struct_missing.ron

Failed in:
  struct pindakaas::bool_linear::AdderEncoder, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/bool_linear.rs:46
  struct pindakaas::bool_linear::BoolLinear, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/bool_linear.rs:122
  struct pindakaas::bool_linear::LinearEncoder, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/bool_linear.rs:174
  struct pindakaas::bool_linear::StaticLinEncoder, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/bool_linear.rs:219
  struct pindakaas::bool_linear::BoolLinExp, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/bool_linear.rs:76
  struct pindakaas::cardinality_one::LadderEncoder, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/cardinality_one.rs:40
  struct pindakaas::bool_linear::BoolLinAggregator, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/bool_linear.rs:68
  struct pindakaas::cardinality_one::PairwiseEncoder, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/cardinality_one.rs:45
  struct pindakaas::bool_linear::TotalizerEncoder, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/bool_linear.rs:241
  struct pindakaas::cardinality::Cardinality, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/cardinality.rs:28
  struct pindakaas::bool_linear::SwcEncoder, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/bool_linear.rs:232
  struct pindakaas::bool_linear::NormalizedBoolLinear, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/bool_linear.rs:187
  struct pindakaas::cardinality_one::BitwiseEncoder, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/cardinality_one.rs:22
  struct pindakaas::propositional_logic::TseitinEncoder, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/propositional_logic.rs:52
  struct pindakaas::cardinality_one::CardinalityOne, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/cardinality_one.rs:33
  struct pindakaas::bool_linear::BddEncoder, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/bool_linear.rs:51
  struct pindakaas::cardinality::SortingNetworkEncoder, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/cardinality.rs:36

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/trait_method_missing.ron

Failed in:
  method add_external_clause of trait Propagator, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/solver/propagation.rs:121
  method add_reason_clause of trait Propagator, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/solver/propagation.rs:132

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/trait_missing.ron

Failed in:
  trait pindakaas::solver::propagation::PropagatorDefinition, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/solver/propagation.rs:188
  trait pindakaas::solver::cadical::ProofTracerDefinition, previously in file /tmp/.tmpHMN9Hm/pindakaas/src/solver/cadical.rs:193
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pindakaas-cadical`

<blockquote>

## [0.4.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-cadical-v0.4.0...pindakaas-cadical-v0.4.1) - 2026-09-18

### Fixed

- C robustness issues

### Other

- cargo +nightly item-sort
- update CaDiCaL to 3.0.1
</blockquote>

## `pindakaas-intel-sat`

<blockquote>

## [0.2.1](https://github.com/pindakaashq/pindakaas/compare/pindakaas-intel-sat-v0.2.0...pindakaas-intel-sat-v0.2.1) - 2026-09-18

### Fixed

- C robustness issues

### Other

- cargo +nightly item-sort
- clarify encoding APIs and expand library documentation
</blockquote>

## `pindakaas-kissat`

<blockquote>

## [0.2.3](https://github.com/pindakaashq/pindakaas/compare/pindakaas-kissat-v0.2.2...pindakaas-kissat-v0.2.3) - 2026-09-18

### Fixed

- C robustness issues

### Other

- cargo +nightly item-sort
- clarify encoding APIs and expand library documentation
- drop `Term` as a type and fix the constant in aggregation
</blockquote>

## `pindakaas`

<blockquote>

## [0.6.0](https://github.com/pindakaashq/pindakaas/compare/pindakaas-v0.5.1...pindakaas-v0.6.0) - 2026-09-18

### Added

- [**breaking**] encode an aggregated constraint with a single encoder
- [**breaking**] add the polynomial watchdog encoding
- add generalized n-level modulo totalizer encoding
- recognise literals counted into an integer
- keep a linear constraint over literals in its literals
- ask an integer variable for the literals of its values
- encode a ternary inequality with the adder where it pays
- build a dense coefficient's product instead of carrying it
- make the sorting network's encoder reachable
- say once that an integer holds a value of its domain
- create and constrain integer variables from Python
- write linear expressions over integers as well as literals
- make the integer constraint interface public
- encode sorting networks over integer variables
- aggregate linear constraints into integer ones
- break linear constraints apart over integer terms
- encode pseudo-Boolean constraints as integer ones
- read a pseudo-Boolean group as the integer it already encodes
- decompose coefficients into shifts and adders
- encode linear constraints over integer variables
- add integer variables holding several Boolean encodings
- add product encoding for at-most-one constraints
- use declared bounds of log encodings during aggregation
- apply greatest common divisor during linear aggregation
- *(external-propagation)* streamline allocation in ExternalPropagation API

### Fixed

- read updated WCNF format
- pair a direct walk's literals with their values in any order
- release a domain borrow before splitting a variable
- decide a constraint by its bounds before decomposing it
- decide a linear constraint by the bounds of its whole sum
- pick the modulo totalizer's base by CaDiCaL cost, not clause count
- encode a count with any of the linear encodings
- read a direct-encoded term against the bound it was given
- leave a sorting network's comparators alone by default
- define the integer linear encoder over ternary constraints
- imply upper bound for groups of mutually exclusive terms
- re-enable already working testcases
- C robustness issues

### Other

- enumerate models through one helper
- return the value of an expression, not a Result
- [**breaking**] name LinExp::terms for the terms it returns
- borrow an integer variable's domain instead of cloning it
- [**breaking**] one handle for what a variable has already encoded
- reject a watchdog constraint its bounds already rule out
- let mixed radix share the short-constraint shortcut
- encode a short constraint as the addition it is
- share configuration and helpers between linear encoders
- skip formatting integer variable labels without tracing
- reuse existing helpers for bit widths and weights
- pair direct-encoding values with their literals
- avoid copying terms in LinExp arithmetic
- fix Sinz citation pages and encoder module doc
- cargo +nightly item-sort
- cargo +nightly fmt
- tighten Rust and Python API documentation
- cap a merge intermediate at the bound above it
- take the sum of two contiguous domains without enumerating it
- walk a ternary constraint in nested loops, not by recursion
- reuse one buffer for the literals of a clause
- add encoding cost and encoding quality benchmarks
- clarify encoding APIs and expand library documentation
- count literals into an integer under the name for it
- name the linear constraint module for what it holds
- measure the named encoder on cardinality constraints too
- cut the documentation back and fill in what was missing
- drop `Term` as a type and fix the constant in aggregation
- keep an integer's products with the integer
- move the cardinality constraint in beside the others
- separate the integer encoder from the constraint it takes
- give each linear encoding its own module
- give each at-most-one encoding its own module
- separate the Tseitin encoding from the formulas it encodes
- put the aggregator where the encoders are
- separate the sorting network from the constraint it encodes
- move the integer decisions in beside the Boolean ones
- give the Boolean decisions a module of their own
- let the integer encoder be an encoder
- name which encoders take a cardinality constraint
- drop the dead normalised Boolean linear constraint
- measure what the integer encodings cost
- generalise the adder circuits over constant bits
- tie the product encoding's selectors to their literals
- drop the fixed literals from the ladder encoding
- clean up linear aggregation
- *(external-propagation)* remove ReasonBuilder
- update itertools from 0.14 to 0.15
</blockquote>

## `pyndakaas`

<blockquote>

## [0.6.0](https://github.com/pindakaashq/pindakaas/compare/pyndakaas-v0.5.1...pyndakaas-v0.6.0) - 2026-09-18

### Added

- expose the product at-most-one encoding to Python
- [**breaking**] encode an aggregated constraint with a single encoder
- [**breaking**] add the polynomial watchdog encoding
- add generalized n-level modulo totalizer encoding
- ask an integer variable for the literals of its values
- create and constrain integer variables from Python
- write linear expressions over integers as well as literals
- aggregate linear constraints into integer ones
- add product encoding for at-most-one constraints

### Fixed

- read updated WCNF format
- encode a count with any of the linear encodings
- read the ends of a variable range from the range itself
- C robustness issues

### Other

- report an unsupported encoder without a lock
- [**breaking**] one handle for what a variable has already encoded
- cargo +nightly item-sort
- cargo +nightly fmt
- tighten Rust and Python API documentation
- clarify encoding APIs and expand library documentation
- name the linear constraint module for what it holds
- cut the documentation back and fill in what was missing
- drop `Term` as a type and fix the constant in aggregation
- move the cardinality constraint in beside the others
- separate the integer encoder from the constraint it takes
- give each linear encoding its own module
- give each at-most-one encoding its own module
- separate the Tseitin encoding from the formulas it encodes
- put the aggregator where the encoders are
- move the integer decisions in beside the Boolean ones
- *(pyndakaas)* build a single abi3 wheel per platform
- update itertools from 0.14 to 0.15
- *(deps)* update pyo3 requirement from 0.28.3 to 0.29.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).